### PR TITLE
Make 'make install' work with less assumptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
 
 install:
   - npm install
-  - make dev-build
+  - make install
 
 script:
   - npm run lint

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ src/script/parse/%parser.js: src/script/parse/%parser_node.js
 src/script/parse/%parser_node.js: src/script/parse/peg/%parser.pegjs 
 	$(PEGJS) $< $@
 
-%.html: src/%.html tracking.id tracking.host VERSION
+%.html: src/%.html tracking.id tracking.host VERSION siteverification.id
 	$(SEDVERSION) < $< > $@
 
 %.css: %.scss

--- a/utl/iosresize.sh
+++ b/utl/iosresize.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 SIZE=`expr "$2" : "[^-]*-\(.*\).png"`
+CONVERT=`which convert`
+OPTIPNG=`which optipng`
 # convert $1  -bordercolor white -border 0 \
-convert $1 -bordercolor white -border 0 \( -clone 0 -resize $SIZEx$SIZE \) -delete 0 -alpha off $2
-optipng -quiet $2
+if [ $CONVERT ]
+then
+    $CONVERT $1 -bordercolor white -border 0 \( -clone 0 -resize $SIZEx$SIZE \) -delete 0 -alpha off $2
+fi
+
+if [ $OPTIPNG ]
+then
+    $OPTIPNG -quiet $2
+fi

--- a/utl/png2favico.sh
+++ b/utl/png2favico.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 # adapted from http://www.imagemagick.org/Usage/thumbnails/#favicon
-optipng -quiet $1
+CONVERT=`which convert`
+OPTIPNG=`which optipng`
+if [ $OPTIPNG ]
+then
+    $OPTIPNG -quiet $1
 # convert $1  -bordercolor white -border 0 \
           # \( -clone 0 -resize 16x16 \) \
           # \( -clone 0 -resize 24x24 \) \
@@ -8,11 +12,15 @@ optipng -quiet $1
           # \( -clone 0 -resize 48x48 \) \
           # \( -clone 0 -resize 64x64 \) \
           # -delete 0 -alpha off -colors 256 $2
+fi
 
-convert $1  \
+if [ $CONVERT ]
+then
+    $CONVERT $1  \
           \( -clone 0 -resize 16x16 \) \
           \( -clone 0 -resize 24x24 \) \
           \( -clone 0 -resize 32x32 \) \
           \( -clone 0 -resize 48x48 \) \
           \( -clone 0 -resize 64x64 \) \
           -delete 0 -alpha on $2
+fi

--- a/utl/resize.sh
+++ b/utl/resize.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
 SIZE=`expr "$2" : "[^-]*-\(.*\).png"`
-convert $1 \( -clone 0 -resize $SIZEx$SIZE \) -delete 0 -alpha on $2
-optipng -quiet $2
+CONVERT=`which convert`
+OPTIPNG=`which optipng`
+if [ $CONVERT ]
+then
+    $CONVERT $1 \( -clone 0 -resize $SIZEx$SIZE \) -delete 0 -alpha on $2
+fi
+
+if [ $OPTIPNG ]
+then
+    $OPTIPNG -quiet $2
+fi


### PR DESCRIPTION
- optipng and convert are not automatically available in each environment
- they're "nice to have" dependencies for generating the favicons. The build should not break on them.
- the makefile didn't mention the siteverification.id file as a dependency (so not auto created)