### PR TITLE
use history api instead of open new window for debug-uri generation

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -256,9 +256,9 @@ Note: the url bar will contain the base64 encoded version of the jpeg">jpg</a>
                 class="debug button" style="display: none"
                 target="_blank"
                 type="text/plain"
-                title="don't use.
+                title="create bookmarkable url
 generates an url that represents current the current interpreter state.
-Useful for debugging with small charts."><span class="icon-share"></span></a>
+Useful for small charts."><span class="icon-share"></span></a>
             </span>
             <div id="__error" class="error" style="display:none">
                 <div class="header">Parse error</div>

--- a/src/script/test/t_controller-exporter.js
+++ b/src/script/test/t_controller-exporter.js
@@ -74,32 +74,43 @@ describe('controller-exporter', function(){
             'data:text/plain;charset=utf-8,msc%20%7B%0A%20%20a%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%2C%0A%20%20b%20%5Blabel%3D%22%E5%BA%8F%22%5D%2C%0A%20%20c%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%3B%0A%0A%20%20a%20%3D%3E%20b%20%5Blabel%3D%22things%22%5D%2C%0Ac%20%3D%3E%20b%3B%0A%7D');
         });
     });
-    describe('#toDebugURI', function(){
-        it('with extra parameters', function(){
+    describe('#getLocationString', function(){
+        it ('with extra parameters', function(){
             var lLocation = {
                 protocol: "http",
                 host: "localhost",
                 pathname: "mscgen_js/index.html",
-                search: '?debug="false"&donottrack="true"'
+                search: '?debug=false&donottrack=true'
             };
-            assert.equal(
-                xport.toDebugURI(lLocation, gMsc, 'mscgen'), 
-                                 "data:text/plain;charset=utf-8,http%2F%2Flocalhostmscgen_js%2Findex.html%3Flang%3Dmscgen%26donottrack%3D%22true%22%26debug%3D%22false%22%26msc%3Dmsc%257Ba%255Blabel%253D%2522%25F0%259F%2592%25A9%2522%255D%252Cb%255Blabel%253D%2522%25E5%25BA%258F%2522%255D%252Cc%2520%255Blabel%253D%2522%25F0%259F%2592%25A9%2522%255D%253B%2520a%2520%253D%253E%2520b%255Blabel%253D%2522things%2522%255D%252C%2520c%2520%253D%253E%2520b%253B%257D");
+            assert.equal(xport.getLocationString(lLocation, gMsc, 'mscgen'),
+                        'mscgen_js/index.html?lang=mscgen&donottrack=true&debug=false&msc=msc%7Ba%5Blabel%3D%22%F0%9F%92%A9%22%5D%2Cb%5Blabel%3D%22%E5%BA%8F%22%5D%2Cc%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%3B%20a%20%3D%3E%20b%5Blabel%3D%22things%22%5D%2C%20c%20%3D%3E%20b%3B%7D');
         });
-        
-        it('without extra parameters', function(){
+        it ('without extra parameters', function(){
             var lLocation = {
                 protocol: "http",
                 host: "localhost",
                 pathname: "mscgen_js/index.html"
             };
-            assert.equal(
-                xport.toDebugURI(lLocation, gMsc, 'mscgen'), 
-                                 "data:text/plain;charset=utf-8,http%2F%2Flocalhostmscgen_js%2Findex.html%3Flang%3Dmscgen%26msc%3Dmsc%257Ba%255Blabel%253D%2522%25F0%259F%2592%25A9%2522%255D%252Cb%255Blabel%253D%2522%25E5%25BA%258F%2522%255D%252Cc%2520%255Blabel%253D%2522%25F0%259F%2592%25A9%2522%255D%253B%2520a%2520%253D%253E%2520b%255Blabel%253D%2522things%2522%255D%252C%2520c%2520%253D%253E%2520b%253B%257D");
-        });
+            assert.equal(xport.getLocationString(lLocation, gMsc, 'mscgen'),
+                        'mscgen_js/index.html?lang=mscgen&msc=msc%7Ba%5Blabel%3D%22%F0%9F%92%A9%22%5D%2Cb%5Blabel%3D%22%E5%BA%8F%22%5D%2Cc%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%3B%20a%20%3D%3E%20b%5Blabel%3D%22things%22%5D%2C%20c%20%3D%3E%20b%3B%7D');
 
+            
+        });
+        it ('with a source that is too big (> 4k)', function(){
+            var lLocation = {
+                protocol: "http",
+                host: "localhost",
+                pathname: "mscgen_js/index.html",
+                search: '?debug=false&donottrack=true'
+            };
+            var l100wString = '# 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890';
+            var lBig = l100wString;
+            for (var i=0;i<40;i++){
+                lBig += l100wString;
+            }
+            assert.equal(xport.getLocationString(lLocation, lBig, 'mscgen'),
+                        'mscgen_js/index.html?lang=mscgen&donottrack=true&debug=false&msc=%23%20source%20too%20long%20for%20an%20URL');
+            
+        });
     });
-    
-    
-    
 });

--- a/src/script/test/t_controller-exporter.js
+++ b/src/script/test/t_controller-exporter.js
@@ -74,7 +74,7 @@ describe('controller-exporter', function(){
             'data:text/plain;charset=utf-8,msc%20%7B%0A%20%20a%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%2C%0A%20%20b%20%5Blabel%3D%22%E5%BA%8F%22%5D%2C%0A%20%20c%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%3B%0A%0A%20%20a%20%3D%3E%20b%20%5Blabel%3D%22things%22%5D%2C%0Ac%20%3D%3E%20b%3B%0A%7D');
         });
     });
-    describe('#getLocationString', function(){
+    describe('#toLocationString', function(){
         it ('with extra parameters', function(){
             var lLocation = {
                 protocol: "http",
@@ -82,7 +82,7 @@ describe('controller-exporter', function(){
                 pathname: "mscgen_js/index.html",
                 search: '?debug=false&donottrack=true'
             };
-            assert.equal(xport.getLocationString(lLocation, gMsc, 'mscgen'),
+            assert.equal(xport.toLocationString(lLocation, gMsc, 'mscgen'),
                         'mscgen_js/index.html?lang=mscgen&donottrack=true&debug=false&msc=msc%7Ba%5Blabel%3D%22%F0%9F%92%A9%22%5D%2Cb%5Blabel%3D%22%E5%BA%8F%22%5D%2Cc%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%3B%20a%20%3D%3E%20b%5Blabel%3D%22things%22%5D%2C%20c%20%3D%3E%20b%3B%7D');
         });
         it ('without extra parameters', function(){
@@ -91,7 +91,7 @@ describe('controller-exporter', function(){
                 host: "localhost",
                 pathname: "mscgen_js/index.html"
             };
-            assert.equal(xport.getLocationString(lLocation, gMsc, 'mscgen'),
+            assert.equal(xport.toLocationString(lLocation, gMsc, 'mscgen'),
                         'mscgen_js/index.html?lang=mscgen&msc=msc%7Ba%5Blabel%3D%22%F0%9F%92%A9%22%5D%2Cb%5Blabel%3D%22%E5%BA%8F%22%5D%2Cc%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%3B%20a%20%3D%3E%20b%5Blabel%3D%22things%22%5D%2C%20c%20%3D%3E%20b%3B%7D');
 
             
@@ -108,7 +108,7 @@ describe('controller-exporter', function(){
             for (var i=0;i<40;i++){
                 lBig += l100wString;
             }
-            assert.equal(xport.getLocationString(lLocation, lBig, 'mscgen'),
+            assert.equal(xport.toLocationString(lLocation, lBig, 'mscgen'),
                         'mscgen_js/index.html?lang=mscgen&donottrack=true&debug=false&msc=%23%20source%20too%20long%20for%20an%20URL');
             
         });

--- a/src/script/ui-control/controller-exporter.js
+++ b/src/script/ui-control/controller-exporter.js
@@ -65,15 +65,7 @@ define(["../render/text/ast2dot",
         toVanillaMscGenURI: function(pAST){
             return 'data:text/plain;charset=utf-8,'+encodeURIComponent(ast2mscgen.render(pAST));
         },
-        getLocationString: getLocationString,
-        toDebugURI: function(pLocation, pSource, pLanguage){
-            return 'data:text/plain;charset=utf-8,'+
-                encodeURIComponent(
-                    pLocation.protocol + '//' +
-                    pLocation.host +
-                    getLocationString(pLocation, pSource, pLanguage)
-                );
-        }
+        getLocationString: getLocationString
     };
 });
 /*

--- a/src/script/ui-control/controller-exporter.js
+++ b/src/script/ui-control/controller-exporter.js
@@ -45,14 +45,6 @@ define(["../render/text/ast2dot",
         return source2LocationString(pLocation, pSource, pLanguage).length < MAX_LOCATION_LENGTH;
     }
     
-    function toLocationString (pLocation, pSource, pLanguage) {
-        var lSource = '# source too long for an URL';
-        if (sourceIsURLable(pLocation, pSource, pLanguage)) {
-            lSource = pSource;
-        }
-        return source2LocationString(pLocation, lSource, pLanguage); 
-    }
-    
     return {
         toVectorURI: function (pSVGSource, pWindow) {
             pWindow = pWindow ? pWindow : window;
@@ -69,7 +61,13 @@ define(["../render/text/ast2dot",
         toVanillaMscGenURI: function(pAST){
             return 'data:text/plain;charset=utf-8,'+encodeURIComponent(ast2mscgen.render(pAST));
         },
-        toLocationString: toLocationString
+        toLocationString: function (pLocation, pSource, pLanguage) {
+            var lSource = '# source too long for an URL';
+            if (sourceIsURLable(pLocation, pSource, pLanguage)) {
+                lSource = pSource;
+            }
+            return source2LocationString(pLocation, lSource, pLanguage); 
+        }
     };
 });
 /*

--- a/src/script/ui-control/controller-exporter.js
+++ b/src/script/ui-control/controller-exporter.js
@@ -34,19 +34,23 @@ define(["../render/text/ast2dot",
         return lAdditionalParameters;
     }
     
-    function getLocationString (pLocation, pSource, pLanguage) {
-        var lRetval = pLocation.pathname +
+    function source2LocationString(pLocation, pSource, pLanguage){
+        return pLocation.pathname +
                 '?lang=' + pLanguage +
                 getAdditionalParameters(pLocation) +
                 '&msc=' + encodeURIComponent(pSource);
-        if (lRetval.length < MAX_LOCATION_LENGTH) {
-            return lRetval;
-        } else {
-            return pLocation.pathname +
-                    '?lang=' + pLanguage +
-                    getAdditionalParameters(pLocation) +
-                    '&msc=' + encodeURIComponent('# source too long for an URL');
+    }
+    
+    function sourceIsURLable(pLocation, pSource, pLanguage){
+        return source2LocationString(pLocation, pSource, pLanguage).length < MAX_LOCATION_LENGTH;
+    }
+    
+    function toLocationString (pLocation, pSource, pLanguage) {
+        var lSource = '# source too long for an URL';
+        if (sourceIsURLable(pLocation, pSource, pLanguage)) {
+            lSource = pSource;
         }
+        return source2LocationString(pLocation, lSource, pLanguage); 
     }
     
     return {
@@ -65,7 +69,7 @@ define(["../render/text/ast2dot",
         toVanillaMscGenURI: function(pAST){
             return 'data:text/plain;charset=utf-8,'+encodeURIComponent(ast2mscgen.render(pAST));
         },
-        getLocationString: getLocationString
+        toLocationString: toLocationString
     };
 });
 /*

--- a/src/script/ui-control/controller-exporter.js
+++ b/src/script/ui-control/controller-exporter.js
@@ -31,7 +31,14 @@ define(["../render/text/ast2dot",
         
         return lAdditionalParameters;
     }
-
+    
+    function getLocationString (pLocation, pSource, pLanguage) {
+        return pLocation.pathname +
+                '?lang=' + pLanguage +
+                getAdditionalParameters(pLocation) +
+                '&msc=' + encodeURIComponent(pSource);
+    }
+    
     return {
         toVectorURI: function (pSVGSource, pWindow) {
             pWindow = pWindow ? pWindow : window;
@@ -48,15 +55,13 @@ define(["../render/text/ast2dot",
         toVanillaMscGenURI: function(pAST){
             return 'data:text/plain;charset=utf-8,'+encodeURIComponent(ast2mscgen.render(pAST));
         },
+        getLocationString: getLocationString,
         toDebugURI: function(pLocation, pSource, pLanguage){
             return 'data:text/plain;charset=utf-8,'+
                 encodeURIComponent(
                     pLocation.protocol + '//' +
                     pLocation.host +
-                    pLocation.pathname +
-                    '?lang=' + pLanguage +
-                    getAdditionalParameters(pLocation) +
-                    '&msc=' + encodeURIComponent(pSource)
+                    getLocationString(pLocation, pSource, pLanguage)
                 );
         }
     };

--- a/src/script/ui-control/controller-exporter.js
+++ b/src/script/ui-control/controller-exporter.js
@@ -13,6 +13,8 @@ define(["../render/text/ast2dot",
         ],
         function(ast2dot, ast2mscgen, par) {
     "use strict";
+    
+    var MAX_LOCATION_LENGTH = 4094;// max length of an URL on github (4122) - "https://sverweij.github.io/".length (27) - 1
 
     function toHTMLSnippet (pSource, pLanguage){
         return "<!DOCTYPE html>\n<html>\n  <head>\n    <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>\n    <script src='https://sverweij.github.io/mscgen_js/mscgen-inpage.js' defer>\n    </script>\n  </head>\n  <body>\n    <pre class='code " + pLanguage + " mscgen_js' data-language='" + pLanguage +"'>\n" + pSource + "\n    </pre>\n  </body>\n</html>";
@@ -33,10 +35,18 @@ define(["../render/text/ast2dot",
     }
     
     function getLocationString (pLocation, pSource, pLanguage) {
-        return pLocation.pathname +
+        var lRetval = pLocation.pathname +
                 '?lang=' + pLanguage +
                 getAdditionalParameters(pLocation) +
                 '&msc=' + encodeURIComponent(pSource);
+        if (lRetval.length < MAX_LOCATION_LENGTH) {
+            return lRetval;
+        } else {
+            return pLocation.pathname +
+                    '?lang=' + pLanguage +
+                    getAdditionalParameters(pLocation) +
+                    '&msc=' + encodeURIComponent('# source too long for an URL');
+        }
     }
     
     return {

--- a/src/script/ui-control/interpreter-output-actions.js
+++ b/src/script/ui-control/interpreter-output-actions.js
@@ -45,7 +45,7 @@ define(["./interpreter-uistate",
             gaga.g('send', 'event', 'show_vanilla', 'button');
         },
         urlOnClick: function() {
-            window.open(xport.toDebugURI(window.location, uistate.getSource(), uistate.getLanguage()));
+            window.history.replaceState({},"", xport.getLocationString(window.location, uistate.getSource(), uistate.getLanguage()));
             gaga.g('send', 'event', 'show_url', 'button');
         },
         animOnClick: function() {

--- a/src/script/ui-control/interpreter-output-actions.js
+++ b/src/script/ui-control/interpreter-output-actions.js
@@ -45,7 +45,7 @@ define(["./interpreter-uistate",
             gaga.g('send', 'event', 'show_vanilla', 'button');
         },
         urlOnClick: function() {
-            window.history.replaceState({},"", xport.getLocationString(window.location, uistate.getSource(), uistate.getLanguage()));
+            window.history.replaceState({},"", xport.toLocationString(window.location, uistate.getSource(), uistate.getLanguage()));
             gaga.g('send', 'event', 'show_url', 'button');
         },
         animOnClick: function() {

--- a/src/script/ui-control/interpreter-param-actions.js
+++ b/src/script/ui-control/interpreter-param-actions.js
@@ -21,11 +21,13 @@ define(["./interpreter-uistate",
     function processParams(){
         var lParams = params.getParams (window.location.search);
         setupGA(lParams.donottrack);
-
+        
+        uistate.setDebug(false);
         if ("true" === lParams.debug) {
             dq.doForAllOfClass("debug", function(pDomNode){
                 dq.SS(pDomNode).show();
             });
+            uistate.setDebug(true);
             gaga.g('send', 'event', 'debug', 'true');
         }
 

--- a/src/script/ui-control/interpreter-param-actions.js
+++ b/src/script/ui-control/interpreter-param-actions.js
@@ -23,7 +23,7 @@ define(["./interpreter-uistate",
         setupGA(lParams.donottrack);
         
         uistate.setDebug(false);
-        if ("true" === lParams.debug) {
+        if (["true", "1", "on"].indexOf(lParams.debug) > -1 ) {
             dq.doForAllOfClass("debug", function(pDomNode){
                 dq.SS(pDomNode).show();
             });

--- a/src/script/ui-control/interpreter-param-actions.js
+++ b/src/script/ui-control/interpreter-param-actions.js
@@ -30,16 +30,17 @@ define(["./interpreter-uistate",
             uistate.setDebug(true);
             gaga.g('send', 'event', 'debug', 'true');
         }
-
+        
+        if (lParams.lang){
+            uistate.setLanguage(lParams.lang);
+            gaga.g('send', 'event', 'params.lang', lParams.lang);
+        }
+        
         if (lParams.msc) {
             uistate.setSource(lParams.msc);
             gaga.g('send', 'event', 'params.msc');
         } else {
             uistate.setSample();
-        }
-        if (lParams.lang){
-            uistate.setLanguage(lParams.lang);
-            gaga.g('send', 'event', 'params.lang', lParams.lang);
         }
     }
 

--- a/src/script/ui-control/interpreter-uistate.js
+++ b/src/script/ui-control/interpreter-uistate.js
@@ -121,7 +121,7 @@ function initializeUI() {
 function msc_inputKeyup () {
     if (gAutoRender) {
         if (gDebug) {
-            window.history.replaceState({},"", xport.getLocationString(window.location, getSource(), getLanguage()));
+            window.history.replaceState({},"", xport.toLocationString(window.location, getSource(), getLanguage()));
         }
         render(getSource(), getLanguage());
     }

--- a/src/script/ui-control/interpreter-uistate.js
+++ b/src/script/ui-control/interpreter-uistate.js
@@ -120,9 +120,6 @@ function initializeUI() {
 
 function msc_inputKeyup () {
     if (gAutoRender) {
-        if (gDebug) {
-            window.history.replaceState({},"", xport.toLocationString(window.location, getSource(), getLanguage()));
-        }
         render(getSource(), getLanguage());
     }
 }
@@ -270,6 +267,16 @@ function render(pSource, pLanguage) {
     preRenderReset();
     try {
         var lAST = getASTBare(pSource, pLanguage);
+        if (gDebug) {
+            window.history.replaceState({},"", 
+                        xport.toLocationString(window.location, 
+                            pSource, 
+                            txt.correctLanguage(lAST.meta.extendedFeatures, 
+                                pLanguage
+                            )
+                        )
+            );
+        }
         msc_render.renderAST(lAST, pSource, "__svg", window);
         if (lAST.entities.length > 0) {
             showRenderSuccess(lAST.meta);

--- a/src/script/ui-control/interpreter-uistate.js
+++ b/src/script/ui-control/interpreter-uistate.js
@@ -44,6 +44,7 @@ define(["../parse/xuparser", "../parse/msgennyparser", "../render/graphics/rende
         "../utl/gaga", "../utl/maps", "../render/text/colorize",
         "../../lib/codemirror/lib/codemirror",
         "../utl/domquery",
+        "./controller-exporter",
         "../../lib/codemirror/addon/edit/closebrackets",
         "../../lib/codemirror/addon/edit/matchbrackets",
         "../../lib/codemirror/addon/display/placeholder",
@@ -54,12 +55,14 @@ define(["../parse/xuparser", "../parse/msgennyparser", "../render/graphics/rende
             tomsgenny, tomscgen,
             gaga, txt, colorize,
             codemirror,
-            dq
+            dq,
+            xport
         ) {
 "use strict";
 
 var gAutoRender = true;
 var gLanguage = "mscgen";
+var gDebug = false;
 var gGaKeyCount = 0;
 
 var gCodeMirror =
@@ -84,7 +87,7 @@ initializeUI();
 function setupEditorEvents(pCodeMirror){
   pCodeMirror.on ("change",
       function() {
-          msc_inputKeyup(getSource(), getLanguage());
+          msc_inputKeyup();
           if (gGaKeyCount > 17) {
               gGaKeyCount = 0;
               gaga.g('send', 'event', '17 characters typed', getLanguage());
@@ -117,6 +120,9 @@ function initializeUI() {
 
 function msc_inputKeyup () {
     if (gAutoRender) {
+        if (gDebug) {
+            window.history.replaceState({},"", xport.getLocationString(window.location, getSource(), getLanguage()));
+        }
         render(getSource(), getLanguage());
     }
 }
@@ -225,6 +231,10 @@ function getLanguage(){
 
 function getAutoRender(){
     return gAutoRender;
+}
+
+function setDebug(pBoolean){
+    gDebug = pBoolean;
 }
 
 function setAutoRender(pBoolean){
@@ -360,6 +370,7 @@ function displayError (pError, pContext) {
         setSource: setSource,
         getLanguage: getLanguage,
         setLanguage: setLanguage,
+        setDebug: setDebug,
         getAST: getAST,
 
         showAutorenderState: showAutorenderState


### PR DESCRIPTION
- ... as suggested in #142 
- the 'generate debug uri' button now changes the url using the history api
- in _debug mode_ the URL gets updated while you type

todo: 
- [x] handle maximum url lengths (on github.io ~4000 characters. Browsers are mostly 'limitless') gracefully e.g.
  - ~~~chop at 2k (rude)~~~
  - ~~~default to empty string (rude, but also clear)~~~
  - ~~~accompany either with a message~~~
  - default to a replacement string e.g. "# source too long for an URL" :arrow_backward: :+1: 
- [x] get a feel for usability on slow machines -> not much worse than normal
- [x] test on various browsers on a windows machine 
  - [x] FF, chrome: :+1: 
  - [x] IE10&11: :-1:
    - IE engine :zap: for lengths > 2k 
    - :turtle: ...
- [x] fix this: after a language switch the language in the url gets updated too late (found in c9371e7, fixed in e8d7886)