### PR TITLE
adds rudimentary doxygen export support

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -266,6 +266,11 @@ Note: !! removes comments and reformats your source!!">b&amp;w</button>
                     target="_blank"
                     type="text/plain"
                     title="exports to vanilla mscgen"><span class="icon-arrow-down"></span></a>
+                <a id="__show_doxygen"
+                    class="debug button" style="display: none"
+                    target="_blank"
+                    type="text/plain"
+                    title="exports to mscgen that can be pasted into doxygen comments">dox</span></a>
             </div><!-- output-controls-area-->
             <div id="__output_content_area">
                 <div id="__error" class="error" style="display:none">

--- a/src/script/cli/ast2doxygen.js
+++ b/src/script/cli/ast2doxygen.js
@@ -1,0 +1,39 @@
+/*
+ * takes a simplified message sequence chart program and translates
+ * to an mscgen program
+ */
+/* jshint indent:4 */
+/* jshint node:true */
+var ast2doxygen = require ("../render/text/ast2doxygen");
+
+var gInput = "";
+
+process.stdin.resume();
+process.stdin.setEncoding('utf8');
+
+process.stdin.on('data', function(chunk) {
+    gInput += chunk;
+});
+
+process.stdin.on('end', function() {
+    var lAST = JSON.parse(gInput);
+    process.stdout.write(ast2doxygen.render (lAST));
+    process.stdin.pause();
+});
+
+/*
+    This file is part of mscgen_js.
+
+    mscgen_js is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    mscgen_js is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with mscgen_js.  If not, see <http://www.gnu.org/licenses/>.
+*/

--- a/src/script/mscgen-interpreter.js
+++ b/src/script/mscgen-interpreter.js
@@ -35,6 +35,7 @@ require(["ui-control/interpreter-input-actions",
       window.__show_html.addEventListener("click", oactions.htmlOnClick, false);
       window.__show_dot.addEventListener("click", oactions.dotOnClick, false);
       window.__show_vanilla.addEventListener("click", oactions.vanillaOnClick, false);
+      window.__show_doxygen.addEventListener("click", oactions.doxygenOnClick, false);
       window.__show_url.addEventListener("click", oactions.urlOnClick, false);
       window.__show_anim.addEventListener("click", oactions.animOnClick, false);
       window.__error.addEventListener("click", oactions.errorOnClick, false);

--- a/src/script/render/text/ast2doxygen.js
+++ b/src/script/render/text/ast2doxygen.js
@@ -1,6 +1,7 @@
 /*
  * takes an abstract syntax tree for a message sequence chart and renders it
- * as an mscgen program.
+ * as an mscgen program that can be pasted directly into a c-style comment,
+ * in a fashion doxygen can pick it up.
  */
 
 /* jshint node:true */

--- a/src/script/render/text/ast2doxygen.js
+++ b/src/script/render/text/ast2doxygen.js
@@ -1,0 +1,110 @@
+/*
+ * takes an abstract syntax tree for a message sequence chart and renders it
+ * as an mscgen program.
+ */
+
+/* jshint node:true */
+/* jshint undef:true */
+/* jshint unused:strict */
+/* jshint indent:4 */
+
+/* istanbul ignore else */
+if ( typeof define !== 'function') {
+    var define = require('amdefine')(module);
+}
+
+define(["./dotmap", "./textutensils", "./ast2thing"], function(map, utl, thing) {
+    "use strict";
+
+    var INDENT = "  ";
+    var SP = " ";
+    var EOL = "\n";
+    var LINE_PREFIX = " * ";
+
+    function renderKind(pKind) {
+        if ("inline_expression" === map.getAggregate(pKind)) {
+            return "--";
+        }
+        return pKind;
+    }
+
+    function renderAttribute(pAttribute) {
+        var lRetVal = "";
+        /* istanbul ignore else */
+        if (pAttribute.name && pAttribute.value) {
+            lRetVal += pAttribute.name + "=\"" + utl.escapeString(pAttribute.value) + "\"";
+        }
+        return lRetVal;
+    }
+    
+    function renderComments() {
+        /* rendering comments within comments, that are eventually output 
+         * to doxygen html - don't think that's going to be necessary
+         * or desired functionality. If it is remember to be able to
+         * - have a solution for nested comments (otherwise: interesting results)
+         * - have a solution for comments that have an other meaning (# this is
+         *    a comment -> doxygen translates this as markdown title)
+         * - handling languages different from c/ java/ d that have alternative
+         *   comment/ documentation sections
+         */
+        return "";
+    }
+
+    return {
+        render : function(pAST) {
+            return thing.render(pAST, {
+                "renderCommentfn" : renderComments,
+                "renderAttributefn" : renderAttribute,
+                "renderKindfn" : renderKind,
+                "supportedOptions" : ["hscale", "width", "arcgradient", "wordwraparcs"],
+                "supportedEntityAttributes" : ["label", "idurl", "id", "url", "linecolor", "textcolor", "textbgcolor", "arclinecolor", "arctextcolor", "arctextbgcolor", "arcskip"],
+                "supportedArcAttributes" : ["label", "idurl", "id", "url", "linecolor", "textcolor", "textbgcolor", "arclinecolor", "arctextcolor", "arctextbgcolor", "arcskip"],
+                "program" : {
+                    "opener" : LINE_PREFIX + "\\msc" + EOL,
+                    "closer" : LINE_PREFIX + "\\endmsc"
+                },
+                "option" : {
+                    "opener" : LINE_PREFIX + INDENT,
+                    "separator" : "," + EOL + LINE_PREFIX + INDENT,
+                    "closer" : ";" + EOL + LINE_PREFIX + EOL
+                },
+                "entity" : {
+                    "opener": LINE_PREFIX + INDENT,
+                    "separator" : "," + EOL + LINE_PREFIX + INDENT,
+                    "closer" : ";" + EOL + LINE_PREFIX + EOL
+                },
+                "attribute" : {
+                    "opener" : SP + "[",
+                    "separator" : "," + SP,
+                    "closer" : "]",
+
+                },
+                "arcline" : {
+                    "opener" : LINE_PREFIX + INDENT,
+                    "separator" : "," + EOL + LINE_PREFIX + INDENT,
+                    "closer" : ";" + EOL
+                },
+                "inline" : {
+                    "opener" : ";" + EOL,
+                    "closer" : LINE_PREFIX + "#"
+                },
+            });
+        }
+    };
+});
+/*
+ This file is part of mscgen_js.
+
+ mscgen_js is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ mscgen_js is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with mscgen_js.  If not, see <http://www.gnu.org/licenses/>.
+ */

--- a/src/script/test/t_ast2doxygen.js
+++ b/src/script/test/t_ast2doxygen.js
@@ -1,0 +1,77 @@
+var assert = require("assert");
+var renderer = require("../render/text/ast2doxygen");
+var parser = require("../parse/mscgenparser_node");
+var fix = require("./astfixtures");
+var utl = require("./testutensils");
+var fs = require("fs");
+
+describe('ast2doxygen', function() {
+    describe('#renderAST() - simple syntax tree', function() {
+        it('should, given a simple syntax tree, render a mscgen script', function() {
+            var lProgram = renderer.render(fix.astSimple);
+            var lExpectedProgram = ' * \\msc\n *   a,\n *   "b space";\n * \n *   a => "b space" [label="a simple script"];\n * \\endmsc';
+            assert.equal(lProgram, lExpectedProgram);
+        });
+
+        it("should preserve the comments at the start of the ast", function() {
+            var lProgram = renderer.render(fix.astWithPreComment);
+            var lExpectedProgram = " * \\msc\n *   a,\n *   b;\n * \n *   a -> b;\n * \\endmsc";
+            assert.equal(lProgram, lExpectedProgram);
+        });
+
+        it("should preserve attributes", function() {
+            var lProgram = renderer.render(fix.astAttributes);
+            var lExpectedProgram = " * \\msc\n *   Alice [linecolor=\"#008800\", textcolor=\"black\", textbgcolor=\"#CCFFCC\", arclinecolor=\"#008800\", arctextcolor=\"#008800\"],\n *   Bob [linecolor=\"#FF0000\", textcolor=\"black\", textbgcolor=\"#FFCCCC\", arclinecolor=\"#FF0000\", arctextcolor=\"#FF0000\"],\n *   pocket [linecolor=\"#0000FF\", textcolor=\"black\", textbgcolor=\"#CCCCFF\", arclinecolor=\"#0000FF\", arctextcolor=\"#0000FF\"];\n * \n *   Alice => Bob [label=\"do something funny\"];\n *   Bob => pocket [label=\"fetch (nose flute)\", textcolor=\"yellow\", textbgcolor=\"green\", arcskip=\"0.5\"];\n *   Bob >> Alice [label=\"PHEEE!\", textcolor=\"green\", textbgcolor=\"yellow\", arcskip=\"0.3\"];\n *   Alice => Alice [label=\"hihihi\", linecolor=\"#654321\"];\n * \\endmsc";
+            assert.equal(lProgram, lExpectedProgram);
+        });
+    });
+
+    describe('#renderAST() - xu compatible', function() {
+        it('alt only - render correct script', function() {
+            var lProgram = renderer.render(fix.astOneAlt);
+            var lExpectedProgram =
+' * \\msc\n\
+ *   a,\n\
+ *   b,\n\
+ *   c;\n\
+ * \n\
+ *   a => b;\n\
+ *   b -- c;\n\
+ *     b => c;\n\
+ *     c >> b;\n\
+ * #;\n\
+ * \\endmsc';
+            assert.equal(lProgram, lExpectedProgram);
+        });
+        it('alt within loop - render correct script', function() {
+            var lProgram = renderer.render(fix.astAltWithinLoop);
+            var lExpectedProgram =
+' * \\msc\n\
+ *   a,\n\
+ *   b,\n\
+ *   c;\n\
+ * \n\
+ *   a => b;\n\
+ *   a -- c [label="label for loop"];\n\
+ *     b -- c [label="label for alt"];\n\
+ *       b -> c [label="-> within alt"];\n\
+ *       c >> b [label=">> within alt"];\n\
+   * #;\n\
+ *     b >> a [label=">> within loop"];\n\
+ * #;\n\
+ *   a =>> a [label="happy-the-peppy - outside"];\n\
+ *   ...;\n\
+ * \\endmsc';
+            assert.equal(lProgram, lExpectedProgram);
+        });
+        it('When presented with an unsupported option, renders the script by simply omitting it', function(){
+            var lProgram = renderer.render(fix.astWithAWatermark);
+            var lExpectedProgram =
+' * \\msc\n\
+ *   a;\n\
+ * \n\
+ * \\endmsc';
+            assert.equal(lProgram, lExpectedProgram);
+        });
+    });
+});

--- a/src/script/test/t_controller-exporter.js
+++ b/src/script/test/t_controller-exporter.js
@@ -80,6 +80,12 @@ describe('controller-exporter', function(){
             'data:text/plain;charset=utf-8,msc%20%7B%0A%20%20a%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%2C%0A%20%20b%20%5Blabel%3D%22%E5%BA%8F%22%5D%2C%0A%20%20c%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%3B%0A%0A%20%20a%20%3D%3E%20b%20%5Blabel%3D%22things%22%5D%2C%0Ac%20%3D%3E%20b%3B%0A%7D');
         });
     });
+    describe('#toDoxygenURI', function(){
+        it('should render an URI encoded doxygen pastable program', function(){
+            assert.equal(xport.toDoxygenURI(gAST), 
+            'data:text/plain;charset=utf-8,%20*%20%5Cmsc%0A%20*%20%20%20a%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%2C%0A%20*%20%20%20b%20%5Blabel%3D%22%E5%BA%8F%22%5D%2C%0A%20*%20%20%20c%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%3B%0A%20*%20%0A%20*%20%20%20a%20%3D%3E%20b%20%5Blabel%3D%22things%22%5D%2C%0A%20*%20%20%20c%20%3D%3E%20b%3B%0A%20*%20%5Cendmsc');
+        });
+    });
     describe('#toLocationString', function(){
         it ('with extra parameters', function(){
             var lLocation = {

--- a/src/script/ui-control/controller-exporter.js
+++ b/src/script/ui-control/controller-exporter.js
@@ -9,9 +9,10 @@ if ( typeof define !== 'function') {
 
 define(["../render/text/ast2dot",
         "../render/text/ast2mscgen",
+        "../render/text/ast2doxygen",
         "../utl/paramslikker",
         ],
-        function(ast2dot, ast2mscgen, par) {
+        function(ast2dot, ast2mscgen, ast2doxygen, par) {
     "use strict";
     
     var MAX_LOCATION_LENGTH = 4094;// max length of an URL on github (4122) - "https://sverweij.github.io/".length (27) - 1
@@ -64,6 +65,9 @@ define(["../render/text/ast2dot",
         },
         toVanillaMscGenURI: function(pAST){
             return 'data:text/plain;charset=utf-8,'+encodeURIComponent(ast2mscgen.render(pAST));
+        },
+        toDoxygenURI: function(pAST){
+            return 'data:text/plain;charset=utf-8,'+encodeURIComponent(ast2doxygen.render(pAST));
         },
         toLocationString: function (pLocation, pSource, pLanguage) {
             var lSource = '# source too long for an URL';

--- a/src/script/ui-control/interpreter-output-actions.js
+++ b/src/script/ui-control/interpreter-output-actions.js
@@ -44,6 +44,10 @@ define(["./interpreter-uistate",
             window.open(xport.toVanillaMscGenURI(uistate.getAST()));
             gaga.g('send', 'event', 'show_vanilla', 'button');
         },
+        doxygenOnClick: function() {
+            window.open(xport.toDoxygenURI(uistate.getAST()));
+            gaga.g('send', 'event', 'show_doxygen', 'button');
+        },
         urlOnClick: function() {
             window.history.replaceState({},"", xport.toLocationString(window.location, uistate.getSource(), uistate.getLanguage()));
             gaga.g('send', 'event', 'show_url', 'button');


### PR DESCRIPTION
An mscgen embedded in doxygen looks a bit different from a regular mscgen (see below). This pull request adds export support for embedding in c-style comments. Other languages (python, and maybe others) might follow.

### Notes:
- comments within/ on top of msc sources are ignored for now. It doesn't seem to make much sense to support those if you think about it...
- as doxygen uses the original, plain vanilla mscgen, extended features are either left out (watermark) or an alternative is used (inline expressions), in line with the vanilla export that is already available in debug mode.

### Differences msc vs msc embedded in doxygen comments:
- it's embedded in a comment 
- it starts with `\msc` and ends with `\endmsc` instead of `msc {` and `}` respectively
