### PR TITLE
Updates CodeMirror MscGen (/xù/ msgenny) mode

### DIFF
--- a/src/lib/codemirror/mode/mscgen/index_xu.html
+++ b/src/lib/codemirror/mode/mscgen/index_xu.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>CodeMirror: xu mode</title>
-    <link rel="stylesheet" href="../../codemirror.css">
+    <link rel="stylesheet" href="../../_codemirror.scss">
     <script src="../../lib/codemirror.js"></script>
     <script src="mscgen.js"></script>
     <style type="text/css">.CodeMirror {border-top: 1px solid black; border-bottom: 1px solid black;}</style>

--- a/src/lib/codemirror/mode/mscgen/mscgen.js
+++ b/src/lib/codemirror/mode/mscgen/mscgen.js
@@ -1,229 +1,186 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+// mode(s) for the sequence chart dsl's mscgen, xù and msgenny
+// For more information on mscgen, see the site of the original author:
+// http://www.mcternan.me.uk/mscgen
+//
+// This mode for mscgen and the two derivative languages were
+// originally made for use in the mscgen_js interpreter
+// (https://sverweij.github.io/mscgen_js)
+
 (function(mod) {
-	if ( typeof exports == "object" && typeof module == "object")// CommonJS
-		mod(require("../../lib/codemirror"));
-	else if ( typeof define == "function" && define.amd)// AMD
-		define(["../../lib/codemirror"], mod);
-	else// Plain browser env
-		mod(CodeMirror);
-})(function(CodeMirror) {//
-	"use strict";
+  if ( typeof exports == "object" && typeof module == "object")// CommonJS
+    mod(require("../../lib/codemirror"));
+  else if ( typeof define == "function" && define.amd)// AMD
+    define(["../../lib/codemirror"], mod);
+  else// Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  "use strict";
 
-	CodeMirror.defineMode("mscgen", function(config, parserConfig) {
-		return {
-			startState : produceStartStateFunction(),
-			copyState : produceCopyStateFunction(),
-			token : produceTokenFunction({
-				"keywords" : ["msc"],
-				"options" : ["hscale", "width", "arcgradient", "wordwraparcs"],
-				"attributes" : ["label", "idurl", "id", "url", "linecolor", "linecolour", "textcolor", "textcolour", "textbgcolor", "textbgcolour", "arclinecolor", "arclinecolour", "arctextcolor", "arctextcolour", "arctextbgcolor", "arctextbgcolour", "arcskip"],
-				"brackets" : [/*"\\[", "\\]", */"\\{", "\\}"],
-				"arcsWords" : ["note", "abox", "rbox", "box"],
-				"arcsOthers" : ["\\|\\|\\|", "\\.\\.\\.", "---", "--", "<->", "==", "<<=>>", "<=>", "\\.\\.", "<<>>", "::", "<:>", "->", "=>>", "=>", ">>", ":>", "<-", "<<=", "<=", "<<", "<:", "x-", "-x"],
-				"singlecomment" : ["//", "#"],
-				"operators" : ["="]
-			}),
-			lineComment : "#",
-			blockCommentStart : "/*",
-			blockCommentEnd : "*/"
-		};
-	});
-	CodeMirror.defineMIME("text/mscgen", "mscgen");
+  CodeMirror.defineMode("mscgen", function() {
+    return {
+      startState : startStateFn,
+      copyState : copyStateFn,
+      token : produceTokenFunction({
+        "keywords" : ["msc"],
+        "options" : ["hscale", "width", "arcgradient", "wordwraparcs"],
+        "attributes" : ["label", "idurl", "id", "url", "linecolor", "linecolour", "textcolor", "textcolour", "textbgcolor", "textbgcolour", "arclinecolor", "arclinecolour", "arctextcolor", "arctextcolour", "arctextbgcolor", "arctextbgcolour", "arcskip"],
+        "brackets" : ["\\{", "\\}"], // [ and  ] are brackets too, but these get handled in with lists
+        "arcsWords" : ["note", "abox", "rbox", "box"],
+        "arcsOthers" : ["\\|\\|\\|", "\\.\\.\\.", "---", "--", "<->", "==", "<<=>>", "<=>", "\\.\\.", "<<>>", "::", "<:>", "->", "=>>", "=>", ">>", ":>", "<-", "<<=", "<=", "<<", "<:", "x-", "-x"],
+        "singlecomment" : ["//", "#"],
+        "operators" : ["="]
+      }),
+      lineComment : "#",
+      blockCommentStart : "/*",
+      blockCommentEnd : "*/"
+    };
+  });
+  CodeMirror.defineMIME("text/x-mscgen", "mscgen");
 
-	CodeMirror.defineMode("xu", function(config, parserConfig) {
-		return {
-			startState : produceStartStateFunction(),
-			copyState : produceCopyStateFunction(),
-			token : produceTokenFunction({
-				"keywords" : ["msc"],
-				"options" : ["hscale", "width", "arcgradient", "wordwraparcs", "watermark"],
-				"attributes" : ["label", "idurl", "id", "url", "linecolor", "linecolour", "textcolor", "textcolour", "textbgcolor", "textbgcolour", "arclinecolor", "arclinecolour", "arctextcolor", "arctextcolour", "arctextbgcolor", "arctextbgcolour", "arcskip"],
-				"brackets" : [/*"\\[", "\\]", */"\\{", "\\}"],
-				"arcsWords" : ["note", "abox", "rbox", "box", "alt", "else", "opt", "break", "par", "seq", "strict", "neg", "critical", "ignore", "consider", "assert", "loop", "ref", "exc"],
-				"arcsOthers" : ["\\|\\|\\|", "\\.\\.\\.", "---", "--", "<->", "==", "<<=>>", "<=>", "\\.\\.", "<<>>", "::", "<:>", "->", "=>>", "=>", ">>", ":>", "<-", "<<=", "<=", "<<", "<:", "x-", "-x"],
-				"singlecomment" : ["//", "#"],
-				"operators" : ["="]
-			}),
-			lineComment : "#",
-			blockCommentStart : "/*",
-			blockCommentEnd : "*/"
-		};
-	});
-	CodeMirror.defineMIME("text/xu", "xu");
+  CodeMirror.defineMode("xu", function() {
+    return {
+      startState : startStateFn,
+      copyState : copyStateFn,
+      token : produceTokenFunction({
+        "keywords" : ["msc"],
+        "options" : ["hscale", "width", "arcgradient", "wordwraparcs", "watermark"],
+        "attributes" : ["label", "idurl", "id", "url", "linecolor", "linecolour", "textcolor", "textcolour", "textbgcolor", "textbgcolour", "arclinecolor", "arclinecolour", "arctextcolor", "arctextcolour", "arctextbgcolor", "arctextbgcolour", "arcskip"],
+        "brackets" : ["\\{", "\\}"],  // [ and  ] are brackets too, but these get handled in with lists
+        "arcsWords" : ["note", "abox", "rbox", "box", "alt", "else", "opt", "break", "par", "seq", "strict", "neg", "critical", "ignore", "consider", "assert", "loop", "ref", "exc"],
+        "arcsOthers" : ["\\|\\|\\|", "\\.\\.\\.", "---", "--", "<->", "==", "<<=>>", "<=>", "\\.\\.", "<<>>", "::", "<:>", "->", "=>>", "=>", ">>", ":>", "<-", "<<=", "<=", "<<", "<:", "x-", "-x"],
+        "singlecomment" : ["//", "#"],
+        "operators" : ["="]
+      }),
+      lineComment : "#",
+      blockCommentStart : "/*",
+      blockCommentEnd : "*/"
+    };
+  });
+  CodeMirror.defineMIME("text/x-xu", "xu");
 
-	CodeMirror.defineMode("msgenny", function(config, parserConfig) {
-		return {
-			startState : produceStartStateFunction(),
-			copyState : produceCopyStateFunction(),
-			token : produceTokenFunction({
-				"keywords" : null,
-				"options" : ["hscale", "width", "arcgradient", "wordwraparcs", "watermark"],
-				"attributes" : null,
-				"brackets" : ["\\{", "\\}"],
-				"arcsWords" : ["note", "abox", "rbox", "box", "alt", "else", "opt", "break", "par", "seq", "strict", "neg", "critical", "ignore", "consider", "assert", "loop", "ref", "exc"],
-				"arcsOthers" : ["\\|\\|\\|", "\\.\\.\\.", "---", "--", "<->", "==", "<<=>>", "<=>", "\\.\\.", "<<>>", "::", "<:>", "->", "=>>", "=>", ">>", ":>", "<-", "<<=", "<=", "<<", "<:", "x-", "-x"],
-				"singlecomment" : ["//", "#"],
-				"operators" : ["="]
-			}),
-			lineComment : "#",
-			blockCommentStart : "/*",
-			blockCommentEnd : "*/"
+  CodeMirror.defineMode("msgenny", function() {
+    return {
+      startState : startStateFn,
+      copyState : copyStateFn,
+      token : produceTokenFunction({
+        "keywords" : null,
+        "options" : ["hscale", "width", "arcgradient", "wordwraparcs", "watermark"],
+        "attributes" : null,
+        "brackets" : ["\\{", "\\}"],
+        "arcsWords" : ["note", "abox", "rbox", "box", "alt", "else", "opt", "break", "par", "seq", "strict", "neg", "critical", "ignore", "consider", "assert", "loop", "ref", "exc"],
+        "arcsOthers" : ["\\|\\|\\|", "\\.\\.\\.", "---", "--", "<->", "==", "<<=>>", "<=>", "\\.\\.", "<<>>", "::", "<:>", "->", "=>>", "=>", ">>", ":>", "<-", "<<=", "<=", "<<", "<:", "x-", "-x"],
+        "singlecomment" : ["//", "#"],
+        "operators" : ["="]
+      }),
+      lineComment : "#",
+      blockCommentStart : "/*",
+      blockCommentEnd : "*/"
 
-		};
-	});
-	CodeMirror.defineMIME("text/msgenny", "msgenny");
+    };
+  });
+  CodeMirror.defineMIME("text/x-msgenny", "msgenny");
 
-	function wordRegexpBoundary(words) {
-		return new RegExp("[^a-z0-9]{0,1}((" + words.join(")|(") + "))\\b", "i");
-	}
+  function wordRegexpBoundary(pWords) {
+    return new RegExp("\\b((" + pWords.join(")|(") + "))\\b", "i");
+  }
 
-	function wordRegexp(words) {
-		return new RegExp("((" + words.join(")|(") + "))", "i");
-	}
+  function wordRegexp(pWords) {
+    return new RegExp("((" + pWords.join(")|(") + "))", "i");
+  }
 
-	function produceStartStateFunction() {
-		return function() {
-			return {
-				inComment : false,
-				inString : false,
-				inAttributeList : false,
-				inScript : false
-			};
-		};
-	}
+  function startStateFn() {
+    return {
+      inComment : false,
+      inString : false,
+      inAttributeList : false,
+      inScript : false
+    };
+  }
 
-	function produceCopyStateFunction() {
-		return function(pState) {
-			return {
-				inComment : pState.inComment,
-				inString : pState.inString,
-				inAttributeList : pState.inAttributeList,
-				inScript : pState.inScript
-			};
-		};
-	}
+  function copyStateFn(pState) {
+    return {
+      inComment : pState.inComment,
+      inString : pState.inString,
+      inAttributeList : pState.inAttributeList,
+      inScript : pState.inScript
+    };
+  }
 
-	function produceTokenFunction(pConfig) {
+  function produceTokenFunction(pConfig) {
 
-		return function(stream, state) {
-			// if (!pConfig.inScript) {
-			// if (pConfig.keywords !== null && stream.match(wordRegexp(pConfig.keywords), true, true)) {
-			// return "keyword";
-			// }
-			// if (stream.match(/{/, true, true)) {
-			// pConfig.inScript = true;
-			// return "bracket";
-			// }
-			// }
-			// if (pConfig.inScript) {
-			// if (stream.match(/}/, true, true)) {
-			// pConfig.inScript = false;
-			// return "bracket";
-			// }
-			if (stream.match(wordRegexp(pConfig.brackets), true, true)) {
-				return "bracket";
-			}
-			/* comments */
-			if (!state.inComment) {
-				if (stream.match(/\/\*[^\*\/]*/, true, true)) {
-					state.inComment = true;
-					return "comment";
-				}
-				if (stream.match(wordRegexp(pConfig.singlecomment), true, true)) {
-					stream.skipToEnd();
-					return "comment";
-				}
-			}
-			if (state.inComment) {
-				if (stream.match(/[^\*\/]*\*\//, true, true)) {
-					state.inComment = false;
-				} else {
-					stream.skipToEnd();
-				}
-				return "comment";
-			}
-			/* strings */
-			if (!state.inString && stream.match(/\"[^\"]*/, true, true)) {
-				state.inString = true;
-				return "string";
-			}
-			if (state.inString) {
-				if (stream.match(/[^\"]*\"/, true, true)) {
-					state.inString = false;
-				} else {
-					stream.skipToEnd();
-				}
-				return "string";
-			}
-			if (stream.match(wordRegexpBoundary(pConfig.options), true, true)) {
-				return "keyword";
-			}
-			if (stream.match(wordRegexpBoundary(pConfig.arcsWords), true, true)) {
-				return "keyword";
-			}
-			if (stream.match(wordRegexp(pConfig.arcsOthers), true, true)) {
-				return "keyword";
-			}
-			if (pConfig.operators !== null && stream.match(wordRegexp(pConfig.operators), true, true)) {
-				return "operator";
-			}
-			/* attribute lists */
-			if (!pConfig.inAttributeList && stream.match(/\[/, true, true)) {
-				pConfig.inAttributeList = true;
-				return "bracket";
-			}
-			if (pConfig.inAttributeList) {
-				if (pConfig.attributes !== null && stream.match(wordRegexpBoundary(pConfig.attributes), true, true)) {
-					return "attribute";
-				}
-				if (stream.match(/]/, true, true)) {
-					pConfig.inAttributeList = false;
-					return "bracket";
-				}
-			}
+    return function(pStream, pState) {
+      if (pStream.match(wordRegexp(pConfig.brackets), true, true)) {
+        return "bracket";
+      }
+      /* comments */
+      if (!pState.inComment) {
+        if (pStream.match(/\/\*[^\*\/]*/, true, true)) {
+          pState.inComment = true;
+          return "comment";
+        }
+        if (pStream.match(wordRegexp(pConfig.singlecomment), true, true)) {
+          pStream.skipToEnd();
+          return "comment";
+        }
+      }
+      if (pState.inComment) {
+        if (pStream.match(/[^\*\/]*\*\//, true, true)) {
+          pState.inComment = false;
+        } else {
+          pStream.skipToEnd();
+        }
+        return "comment";
+      }
+      /* strings */
+      if (!pState.inString && pStream.match(/\"(\\\"|[^\"])*/, true, true)) {
+        pState.inString = true;
+        return "string";
+      }
+      if (pState.inString) {
+        if (pStream.match(/[^\"]*\"/, true, true)) {
+          pState.inString = false;
+        } else {
+          pStream.skipToEnd();
+        }
+        return "string";
+      }
+      /* keywords & operators */
+      if (!!pConfig.keywords && pStream.match(wordRegexpBoundary(pConfig.keywords), true, true)) {
+        return "keyword";
+      }
+      if (pStream.match(wordRegexpBoundary(pConfig.options), true, true)) {
+        return "keyword";
+      }
+      if (pStream.match(wordRegexpBoundary(pConfig.arcsWords), true, true)) {
+        return "keyword";
+      }
+      if (pStream.match(wordRegexp(pConfig.arcsOthers), true, true)) {
+        return "keyword";
+      }
+      if (!!pConfig.operators && pStream.match(wordRegexp(pConfig.operators), true, true)) {
+        return "operator";
+      }
+      /* attribute lists */
+      if (!pConfig.inAttributeList && !!pConfig.attributes && pStream.match(/\[/, true, true)) {
+        pConfig.inAttributeList = true;
+        return "bracket";
+      }
+      if (pConfig.inAttributeList) {
+        if (pConfig.attributes !== null && pStream.match(wordRegexpBoundary(pConfig.attributes), true, true)) {
+          return "attribute";
+        }
+        if (pStream.match(/]/, true, true)) {
+          pConfig.inAttributeList = false;
+          return "bracket";
+        }
+      }
 
-			// }
-
-			var ch = stream.next();
-			return "base";
-		};
-	}
+      pStream.next();
+      return "base";
+    };
+  }
 
 });
-
-/* DEFAULT THEME
-
- .cm-s-default .cm-keyword {color: #708;}
- .cm-s-default .cm-atom {color: #219;}
- .cm-s-default .cm-number {color: #164;}
- .cm-s-default .cm-def {color: #00f;}
- .cm-s-default .cm-variable {color: black;}
- .cm-s-default .cm-variable-2 {color: #05a;}
- .cm-s-default .cm-variable-3 {color: #085;}
- .cm-s-default .cm-property {color: black;}
- .cm-s-default .cm-operator {color: black;}
- .cm-s-default .cm-comment {color: #a50;}
- .cm-s-default .cm-string {color: #a11;}
- .cm-s-default .cm-string-2 {color: #f50;}
- .cm-s-default .cm-meta {color: #555;}
- .cm-s-default .cm-error {color: #f00;}
- .cm-s-default .cm-qualifier {color: #555;}
- .cm-s-default .cm-builtin {color: #30a;}
- .cm-s-default .cm-bracket {color: #997;}
- .cm-s-default .cm-tag {color: #170;}
- .cm-s-default .cm-attribute {color: #00c;}
- .cm-s-default .cm-header {color: blue;}
- .cm-s-default .cm-quote {color: #090;}
- .cm-s-default .cm-hr {color: #999;}
- .cm-s-default .cm-link {color: #00c;}
-
- .cm-negative {color: #d44;}
- .cm-positive {color: #292;}
- .cm-header, .cm-strong {font-weight: bold;}
- .cm-em {font-style: italic;}
- .cm-link {text-decoration: underline;}
-
- .cm-invalidchar {color: #f00;}
-
- div.CodeMirror span.CodeMirror-matchingbracket {color: #0f0;}
- div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
- */

--- a/src/lib/codemirror/mode/mscgen/test.js
+++ b/src/lib/codemirror/mode/mscgen/test.js
@@ -1,0 +1,15 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+(function() {
+  var mode = CodeMirror.getMode({indentUnit: 2}, "mscgen");
+  function MT(name) { test.mode(name, mode, Array.prototype.slice.call(arguments, 1)); }
+
+  MT("empty chart",
+     "[keyword msc] [bracket {] [bracket }]");
+msc {}
+  MT("comma-and-binop",
+     "[keyword function](){ [keyword var] [def x] [operator =] [number 1] [operator +] [number 2], [def y]; }");
+
+
+})();


### PR DESCRIPTION
- keywords now don't include space-likes when matched (this is not visible in regular themes b.t.w. - and certainly not in those in use in the interpreter)
- escaped quotes in strings now don't end strings anymore, so "a string with an escaped quote \" is now matched as a whole"
- options c.s. are not matched anymore in msgenny
- got rid of some unnnecessary complexity
- added (fairly complete) CodeMirror style test suite

Also see PR 3523 in the codemirror/CodeMirror repo