### PR TITLE
Feature/enables feature branch deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-.SUFFIXES:
+
 .SUFFIXES: .js .pegjs .css .html .msc .mscin .msgenny .svg .png .jpg
 PEGJS=node_modules/pegjs/bin/pegjs
 RJS=node_modules/requirejs/bin/r.js
 GIT=git
-GIT_CURRENT_BRANCH=$(shell git branch | grep "*" | cut -c 3-)
+GIT_CURRENT_BRANCH=$(shell utl/get_current_git_branch.sh)
 GIT_DEPLOY_FROM_BRANCH=master
 CSSLINT=node node_modules/csslint/cli.js --format=compact --quiet --ignore=ids
 CJS2AMD=utl/commonjs2amd.sh

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ SEDVERSION=utl/sedversion.sh
 NPM=npm
 SASS=node_modules/node-sass/bin/node-sass --output-style compressed
 
+ifeq ($(GIT_DEPLOY_FROM_BRANCH), $(GIT_CURRENT_BRANCH))
+	BUILDDIR=build
+else
+	BUILDDIR=build/branches/$(GIT_CURRENT_BRANCH)
+endif
+
 GENERATED_SOURCES_WEB=src/script/parse/mscgenparser.js \
 	src/script/parse/msgennyparser.js \
 	src/script/parse/xuparser.js
@@ -24,7 +30,6 @@ GENERATED_SOURCES_NODE=src/script/parse/mscgenparser_node.js \
 	src/script/parse/xuparser_node.js 
 GENERATED_SOURCES=$(GENERATED_SOURCES_WEB) $(GENERATED_SOURCES_NODE) $(GENERATED_STYLESHEETS)
 SOURCES_NODE=$(GENERATED_SOURCES_NODE)
-BUILDDIR=build
 REMOVABLEPRODDIRS=$(BUILDDIR)/lib \
 	$(BUILDDIR)/style \
 	$(BUILDDIR)/script \
@@ -42,17 +47,17 @@ FAVICONS=$(BUILDDIR)/favicon.ico \
 	$(BUILDDIR)/favicon-32.png \
 	$(BUILDDIR)/favicon-48.png \
 	$(BUILDDIR)/favicon-64.png \
+	$(BUILDDIR)/favicon-128.png \
+	$(BUILDDIR)/favicon-144.png \
+	$(BUILDDIR)/favicon-152.png \
+	$(BUILDDIR)/favicon-195.png \
+	$(BUILDDIR)/favicon-228.png \
 	$(BUILDDIR)/iosfavicon-57.png \
 	$(BUILDDIR)/iosfavicon-72.png \
-	$(BUILDDIR)/favicon-96.png \
 	$(BUILDDIR)/iosfavicon-114.png \
 	$(BUILDDIR)/iosfavicon-120.png \
-	$(BUILDDIR)/favicon-144.png \
 	$(BUILDDIR)/iosfavicon-144.png \
-	$(BUILDDIR)/favicon-152.png \
-	$(BUILDDIR)/iosfavicon-152.png \
-	$(BUILDDIR)/favicon-195.png \
-	$(BUILDDIR)/favicon-228.png
+	$(BUILDDIR)/iosfavicon-152.png
 
 .PHONY: help dev-build install deploy-gh-pages check mostlyclean clean noconsolestatements consolecheck lint cover prerequisites report test
 
@@ -82,8 +87,9 @@ help:
 	@echo " removes everything created by either install or dev-build"
 	@echo
 	@echo "deploy-gh-pages"
-	@echo " deploys the build to gh-pages (only works in the"
-	@echo " '$(GIT_DEPLOY_FROM_BRANCH)' branch)"
+	@echo " deploys the build to gh-pages"
+	@echo "  - 'master' branch: the root of gh-pages"
+	@echo "  - other branches : in branches/branche-name"
 	@echo
 	@echo " --------------------------------------------------------"
 	@echo "| More information and other targets: see wikum/build.md |"
@@ -214,19 +220,11 @@ cover: dev-build
 install: $(BUILDDIR)/index.html $(BUILDDIR)/embed.html $(BUILDDIR)/tutorial.html
 
 deploy-gh-pages: install
-ifeq ($(GIT_DEPLOY_FROM_BRANCH),$(GIT_CURRENT_BRANCH))
-	@echo Deploying build `cat VERSION` ...
+	@echo Deploying build `cat VERSION` to $(BUILDDIR)
 	$(GIT) -C $(BUILDDIR) add --all .
 	$(GIT) -C $(BUILDDIR) commit -m "build `cat VERSION`"
 	$(GIT) -C $(BUILDDIR) push origin gh-pages
 	$(GIT) -C $(BUILDDIR) status
-else
-	@echo
-	@echo Not deploying
-	@echo "  To prevent booboos deploying only works from the '$(GIT_DEPLOY_FROM_BRANCH)' branch."
-	@echo "  Current branch: '$(GIT_CURRENT_BRANCH)'"
-	@echo
-endif
 
 tag: 
 	$(GIT) tag -a `cat VERSION` -m "tag release `cat VERSION`"

--- a/utl/get_current_git_branch.sh
+++ b/utl/get_current_git_branch.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+BRANCH=`git branch | grep "^* [a-zA-Z]" | cut -c 3- ` 
+SANE_BRANCH_NAME=`echo $BRANCH | grep '^[a-zA-Z0-9_/-]\+$'`
+if [ $SANE_BRANCH_NAME ]
+then
+    echo $BRANCH
+else
+    echo branch-name-too-weird-so-we-took-this-for-a-name
+fi


### PR DESCRIPTION
### Local feature branch deployments
- when on the _master_ branch an _install_  installs in `build`
- when on another branch a _deploy-gh-pages_ installs in `build/branches/{{branch_name}}`. This means the branch will be available on https://sverweij.github.io/mscgen_js/branches/{{branch_name}}
  - for this to work the branch name has to be 'sane' - it should easily translate into valid filenames/ directory names. We currently match against `^[a-zA-Z0-9/-]+$`, so
    - sane: `this-is-a-branch-yo`, `feature/Houd-je-bek`, `hotffix/oops_hope_nobody_sees_this123`
    - not sane: `(detached in 23497sdjkf2345dgfb)`, `me so krazy`, `feature/:love:`
  - not sane branches get deployed in `build/branches/branch-name-too-weird-so-we-took-this-for-a-name`
- a _deploy-gh-pages_ will do the same as install, will also add/ commit/ push to gh-pages

### Note on travis
travis (and probably other CI providers) will use a _detached branch_. It's doing a `git checkout -qf {{commit-hash}}` to be sure it's running against the correct commit. As a consequence
- the branch name looks like `(detached in {{commit-hash}}`
- the branch name is not 'sane'
- installation will commence in the `build/branches/branch-name-too-weird-so-we-took-this-for-a-name` folder

(pushing to gh-pages from travis will need some work anyway ...)