### PR TITLE
[parser] Adds more correct location information for entity not define…

### DIFF
--- a/src/script/parse/mscgenparser_node.js
+++ b/src/script/parse/mscgenparser_node.js
@@ -104,6 +104,9 @@ module.exports = (function() {
         peg$c36 = { type: "literal", value: "]", description: "\"]\"" },
         peg$c37 = function(i, a) {return a},
         peg$c38 = function(i, al) {
+          if (isKeyword(i)){
+            error("Keywords aren't allowed as entity names");
+          }
           var lOption = {};
           lOption["name"] = i;
           return merge (lOption, al);
@@ -2782,6 +2785,15 @@ module.exports = (function() {
             });
         }
 
+        function isKeyword(pString){
+            return ["box", "abox", "rbox", "note", "msc", "hscale", "width", "arcgradient",
+               "wordwraparcs", "label", "color", "idurl", "id", "url",
+               "linecolor", "linecolour", "textcolor", "textcolour",
+               "textbgcolor", "textbgcolour", "arclinecolor", "arclinecolour",
+               "arctextcolor", "arctextcolour","arctextbgcolor", "arctextbgcolour",
+               "arcskip"].indexOf(pString) > -1;
+        }
+        
         function buildEntityNotDefinedMessage(pEntityName, pArc){
             return "Entity '" + pEntityName + "' in arc " +
                    "'" + pArc.from + " " + pArc.kind + " " + pArc.to + "' " +

--- a/src/script/parse/mscgenparser_node.js
+++ b/src/script/parse/mscgenparser_node.js
@@ -71,16 +71,16 @@ module.exports = (function() {
         },
         peg$c16 = "=",
         peg$c17 = { type: "literal", value: "=", description: "\"=\"" },
-        peg$c18 = function(n, s) {return s},
-        peg$c19 = function(n, i) {return i.toString()},
-        peg$c20 = function(n, b) {return b.toString()},
-        peg$c21 = function(n, v) {
+        peg$c18 = function(name, s) {return s},
+        peg$c19 = function(name, i) {return i.toString()},
+        peg$c20 = function(name, b) {return b.toString()},
+        peg$c21 = function(name, value) {
            var lOption = {};
-           n = n.toLowerCase();
-           if (n === "wordwraparcs"){
-              lOption[n] = flattenBoolean(v);
+           name = name.toLowerCase();
+           if (name === "wordwraparcs"){
+              lOption[name] = flattenBoolean(value);
            } else {
-              lOption[n]=v;
+              lOption[name]=value;
            }
            return lOption;
         },
@@ -102,14 +102,12 @@ module.exports = (function() {
         peg$c34 = { type: "literal", value: "[", description: "\"[\"" },
         peg$c35 = "]",
         peg$c36 = { type: "literal", value: "]", description: "\"]\"" },
-        peg$c37 = function(i, a) {return a},
-        peg$c38 = function(i, al) {
-          if (isKeyword(i)){
+        peg$c37 = function(name, a) {return a},
+        peg$c38 = function(name, attrList) {
+          if (isKeyword(name)){
             error("Keywords aren't allowed as entity names");
           }
-          var lOption = {};
-          lOption["name"] = i;
-          return merge (lOption, al);
+          return merge ({name:name}, attrList);
         },
         peg$c39 = function(a) {return a},
         peg$c40 = function(a) {return [a]},
@@ -189,11 +187,11 @@ module.exports = (function() {
         peg$c108 = { type: "literal", value: "rbox", description: "\"rbox\"" },
         peg$c109 = "box",
         peg$c110 = { type: "literal", value: "box", description: "\"box\"" },
-        peg$c111 = function(n, v) {
+        peg$c111 = function(name, value) {
           var lAttribute = {};
-          n = n.toLowerCase();
-          n = n.replace("colour", "color");
-          lAttribute[n] = v;
+          name = name.toLowerCase();
+          name = name.replace("colour", "color");
+          lAttribute[name] = value;
           return lAttribute
         },
         peg$c112 = { type: "other", description: "attribute name" },

--- a/src/script/parse/mscgenparser_node.js
+++ b/src/script/parse/mscgenparser_node.js
@@ -120,11 +120,11 @@ module.exports = (function() {
           return merge (a, al);
         },
         peg$c44 = function(kind) {return {kind:kind}},
-        peg$c45 = function(from, kind, to) {return {kind: kind, from:from, to:to}},
+        peg$c45 = function(from, kind, to) {return {kind: kind, from:from, to:to, location:location()}},
         peg$c46 = "*",
         peg$c47 = { type: "literal", value: "*", description: "\"*\"" },
-        peg$c48 = function(kind, to) {return {kind:kind, from: "*", to:to}},
-        peg$c49 = function(from, kind) {return {kind:kind, from: from, to:"*"}},
+        peg$c48 = function(kind, to) {return {kind:kind, from: "*", to:to, location:location()}},
+        peg$c49 = function(from, kind) {return {kind:kind, from: from, to:"*", location:location()}},
         peg$c50 = "|||",
         peg$c51 = { type: "literal", value: "|||", description: "\"|||\"" },
         peg$c52 = "...",
@@ -2782,11 +2782,18 @@ module.exports = (function() {
             });
         }
 
+        function buildEntityNotDefinedMessage(pEntityName, pArc){
+            return "Entity '" + pEntityName + "' in arc " +
+                   "'" + pArc.from + " " + pArc.kind + " " + pArc.to + "' " +
+                   "is not defined.";    
+        }
+
         function EntityNotDefinedError (pEntityName, pArc) {
-            this.message = "Entity '" + pEntityName + "' in arc ";
-            this.message += "'" + pArc.from + " " + pArc.kind + " " + pArc.to + "' ";
-            this.message += "is not defined.";
             this.name = "EntityNotDefinedError";
+            this.message = buildEntityNotDefinedMessage(pEntityName, pArc);
+            this.location = pArc.location;
+            this.location.start.line++;
+            this.location.end.line++;
         }
 
         function checkForUndeclaredEntities (pEntities, pArcLineList) {
@@ -2803,6 +2810,9 @@ module.exports = (function() {
                         }
                         if (pArc.to && !entityExists (pEntities, pArc.to)) {
                             throw new EntityNotDefinedError(pArc.to, pArc);
+                        }
+                        if (!!pArc.location) {
+                            delete pArc.location;
                         }
                     });
                 });

--- a/src/script/parse/mscgenparser_node.js
+++ b/src/script/parse/mscgenparser_node.js
@@ -2791,9 +2791,12 @@ module.exports = (function() {
         function EntityNotDefinedError (pEntityName, pArc) {
             this.name = "EntityNotDefinedError";
             this.message = buildEntityNotDefinedMessage(pEntityName, pArc);
-            this.location = pArc.location;
-            this.location.start.line++;
-            this.location.end.line++;
+            /* istanbul ignore else  */
+            if(!!pArc.location){
+                this.location = pArc.location;
+                this.location.start.line++;
+                this.location.end.line++;        
+            }
         }
 
         function checkForUndeclaredEntities (pEntities, pArcLineList) {

--- a/src/script/parse/msgennyparser.js
+++ b/src/script/parse/msgennyparser.js
@@ -65,18 +65,18 @@ define ([], function() {
         },
         peg$c10 = "=",
         peg$c11 = { type: "literal", value: "=", description: "\"=\"" },
-        peg$c12 = function(n, s) {return s},
-        peg$c13 = function(n, i) {return i.toString()},
-        peg$c14 = function(n, b) {return b.toString()},
-        peg$c15 = function(n, v) {
-           var lOption = {};
-           n = n.toLowerCase();
-           if (n === "wordwraparcs"){
-              lOption[n] = flattenBoolean(v);
-           } else {
-              lOption[n]=v;
-           }
-           return lOption;
+        peg$c12 = function(name, s) {return s},
+        peg$c13 = function(name, i) {return i.toString()},
+        peg$c14 = function(name, b) {return b.toString()},
+        peg$c15 = function(name, value) {
+          var lOption = {};
+          name = name.toLowerCase();
+          if (name === "wordwraparcs"){
+            lOption[name] = flattenBoolean(value);
+          } else {
+            lOption[name]=value;
+          }
+          return lOption;
         },
         peg$c16 = "hscale",
         peg$c17 = { type: "literal", value: "hscale", description: "\"hscale\"" },
@@ -96,12 +96,12 @@ define ([], function() {
         peg$c28 = { type: "other", description: "entity" },
         peg$c29 = ":",
         peg$c30 = { type: "literal", value: ":", description: "\":\"" },
-        peg$c31 = function(i, l) {return l},
-        peg$c32 = function(i, l) {
+        peg$c31 = function(name, l) {return l},
+        peg$c32 = function(name, label) {
           var lEntity = {};
-          lEntity["name"] = i;
-          if (l) {
-            lEntity["label"] = l;
+          lEntity.name = name;
+          if (!!label) {
+            lEntity.label = label;
           }
           return lEntity;
         },
@@ -118,7 +118,7 @@ define ([], function() {
         peg$c39 = function(ra, s) {return s},
         peg$c40 = function(ra, label) {
           if (label) {
-            ra["label"] = label;
+            ra.label = label;
           }
           return ra;
         },
@@ -136,7 +136,7 @@ define ([], function() {
         peg$c52 = function(from, kind, to, label, arcs) {
             var retval = {kind: kind, from:from, to:to, arcs:arcs};
             if (label) {
-              retval["label"] = label;
+              retval.label = label;
             }
             return retval;
           },

--- a/src/script/parse/msgennyparser_node.js
+++ b/src/script/parse/msgennyparser_node.js
@@ -65,18 +65,18 @@ module.exports = (function() {
         },
         peg$c10 = "=",
         peg$c11 = { type: "literal", value: "=", description: "\"=\"" },
-        peg$c12 = function(n, s) {return s},
-        peg$c13 = function(n, i) {return i.toString()},
-        peg$c14 = function(n, b) {return b.toString()},
-        peg$c15 = function(n, v) {
-           var lOption = {};
-           n = n.toLowerCase();
-           if (n === "wordwraparcs"){
-              lOption[n] = flattenBoolean(v);
-           } else {
-              lOption[n]=v;
-           }
-           return lOption;
+        peg$c12 = function(name, s) {return s},
+        peg$c13 = function(name, i) {return i.toString()},
+        peg$c14 = function(name, b) {return b.toString()},
+        peg$c15 = function(name, value) {
+          var lOption = {};
+          name = name.toLowerCase();
+          if (name === "wordwraparcs"){
+            lOption[name] = flattenBoolean(value);
+          } else {
+            lOption[name]=value;
+          }
+          return lOption;
         },
         peg$c16 = "hscale",
         peg$c17 = { type: "literal", value: "hscale", description: "\"hscale\"" },
@@ -96,12 +96,12 @@ module.exports = (function() {
         peg$c28 = { type: "other", description: "entity" },
         peg$c29 = ":",
         peg$c30 = { type: "literal", value: ":", description: "\":\"" },
-        peg$c31 = function(i, l) {return l},
-        peg$c32 = function(i, l) {
+        peg$c31 = function(name, l) {return l},
+        peg$c32 = function(name, label) {
           var lEntity = {};
-          lEntity["name"] = i;
-          if (l) {
-            lEntity["label"] = l;
+          lEntity.name = name;
+          if (!!label) {
+            lEntity.label = label;
           }
           return lEntity;
         },
@@ -118,7 +118,7 @@ module.exports = (function() {
         peg$c39 = function(ra, s) {return s},
         peg$c40 = function(ra, label) {
           if (label) {
-            ra["label"] = label;
+            ra.label = label;
           }
           return ra;
         },
@@ -136,7 +136,7 @@ module.exports = (function() {
         peg$c52 = function(from, kind, to, label, arcs) {
             var retval = {kind: kind, from:from, to:to, arcs:arcs};
             if (label) {
-              retval["label"] = label;
+              retval.label = label;
             }
             return retval;
           },

--- a/src/script/parse/peg/mscgenparser.pegjs
+++ b/src/script/parse/peg/mscgenparser.pegjs
@@ -62,11 +62,18 @@
         });
     }
 
+    function buildEntityNotDefinedMessage(pEntityName, pArc){
+        return "Entity '" + pEntityName + "' in arc " +
+               "'" + pArc.from + " " + pArc.kind + " " + pArc.to + "' " +
+               "is not defined.";    
+    }
+
     function EntityNotDefinedError (pEntityName, pArc) {
-        this.message = "Entity '" + pEntityName + "' in arc ";
-        this.message += "'" + pArc.from + " " + pArc.kind + " " + pArc.to + "' ";
-        this.message += "is not defined.";
         this.name = "EntityNotDefinedError";
+        this.message = buildEntityNotDefinedMessage(pEntityName, pArc);
+        this.location = pArc.location;
+        this.location.start.line++;
+        this.location.end.line++;
     }
 
     function checkForUndeclaredEntities (pEntities, pArcLineList) {
@@ -83,6 +90,9 @@
                     }
                     if (pArc.to && !entityExists (pEntities, pArc.to)) {
                         throw new EntityNotDefinedError(pArc.to, pArc);
+                    }
+                    if (!!pArc.location) {
+                        delete pArc.location;
                     }
                 });
             });
@@ -174,11 +184,11 @@ singlearc       = _ kind:singlearctoken _ {return {kind:kind}}
 commentarc      = _ kind:commenttoken _ {return {kind:kind}}
 dualarc         =
  (_ from:identifier _ kind:dualarctoken _ to:identifier _
-  {return {kind: kind, from:from, to:to}})
+  {return {kind: kind, from:from, to:to, location:location()}})
 /(_ "*" _ kind:bckarrowtoken _ to:identifier _
-  {return {kind:kind, from: "*", to:to}})
+  {return {kind:kind, from: "*", to:to, location:location()}})
 /(_ from:identifier _ kind:fwdarrowtoken _ "*" _
-  {return {kind:kind, from: from, to:"*"}})
+  {return {kind:kind, from: from, to:"*", location:location()}})
 singlearctoken  = "|||" / "..."
 commenttoken    = "---"
 dualarctoken    = kind:(

--- a/src/script/parse/peg/mscgenparser.pegjs
+++ b/src/script/parse/peg/mscgenparser.pegjs
@@ -142,17 +142,17 @@ optionlist      = options:((o:option "," {return o})*
   return optionArray2Object(options);
 }
 
-option          = _ n:optionname _ "=" _
-                  v:(s:string {return s}
+option          = _ name:optionname _ "=" _
+                  value:(s:string {return s}
                      / i:number {return i.toString()}
                      / b:boolean {return b.toString()}) _
 {
    var lOption = {};
-   n = n.toLowerCase();
-   if (n === "wordwraparcs"){
-      lOption[n] = flattenBoolean(v);
+   name = name.toLowerCase();
+   if (name === "wordwraparcs"){
+      lOption[name] = flattenBoolean(value);
    } else {
-      lOption[n]=v;
+      lOption[name]=value;
    }
    return lOption;
 }
@@ -163,14 +163,12 @@ entitylist      = el:((e:entity "," {return e})* (e:entity ";" {return e}))
   el[0].push(el[1]);
   return el[0];
 }
-entity "entity" =  _ i:identifier _ al:("[" a:attributelist  "]" {return a})? _
+entity "entity" =  _ name:identifier _ attrList:("[" a:attributelist  "]" {return a})? _
 {
-  if (isKeyword(i)){
+  if (isKeyword(name)){
     error("Keywords aren't allowed as entity names");
   }
-  var lOption = {};
-  lOption["name"] = i;
-  return merge (lOption, al);
+  return merge ({name:name}, attrList);
 }
 arclist         = (a:arcline _ ";" {return a})+
 arcline         = al:((a:arc _ "," {return a})* (a:arc {return [a]}))
@@ -220,12 +218,12 @@ attributelist   = options:((a:attribute "," {return a})* (a:attribute {return a}
   return optionArray2Object(options);
 }
 
-attribute       = _ n:attributename _ "=" _ v:identifier _
+attribute       = _ name:attributename _ "=" _ value:identifier _
 {
   var lAttribute = {};
-  n = n.toLowerCase();
-  n = n.replace("colour", "color");
-  lAttribute[n] = v;
+  name = name.toLowerCase();
+  name = name.replace("colour", "color");
+  lAttribute[name] = value;
   return lAttribute
 }
 attributename  "attribute name"

--- a/src/script/parse/peg/mscgenparser.pegjs
+++ b/src/script/parse/peg/mscgenparser.pegjs
@@ -17,16 +17,8 @@
  *     to C, as does "C" -> C and "C" -> "C"
  *   mscgen_js does not render the entities as separate ones
  * - in mscgen grammar, only the option list is optional;
- *   empty input (no entities/ no arcs) is apparently not allowed
- *   mscgen_js does allow this
- * - mscgen cannot handle entity names that are also keywords
- *   (box, abox, rbox, not, msc, hscale, width, arcgradient
- *   wordwraparcs, label, color, idurl, id, url
- *   linecolor, linecolour, textcolor, textcolour,
- *   textbgcolor, textbgcolour, arclinecolor, arclinecolour,
- *   arctextcolor, arctextcolour,arctextbgcolor, arctextbgcolour,
- *   arcskip). This grammar does allow them for now. 
- *
+ *   empty input (no entities/ no arcs) is not allowed
+ *   mscgen_js does allow this.
  */
 
 {
@@ -62,6 +54,15 @@
         });
     }
 
+    function isKeyword(pString){
+        return ["box", "abox", "rbox", "note", "msc", "hscale", "width", "arcgradient",
+           "wordwraparcs", "label", "color", "idurl", "id", "url",
+           "linecolor", "linecolour", "textcolor", "textcolour",
+           "textbgcolor", "textbgcolour", "arclinecolor", "arclinecolour",
+           "arctextcolor", "arctextcolour","arctextbgcolor", "arctextbgcolour",
+           "arcskip"].indexOf(pString) > -1;
+    }
+    
     function buildEntityNotDefinedMessage(pEntityName, pArc){
         return "Entity '" + pEntityName + "' in arc " +
                "'" + pArc.from + " " + pArc.kind + " " + pArc.to + "' " +
@@ -164,6 +165,9 @@ entitylist      = el:((e:entity "," {return e})* (e:entity ";" {return e}))
 }
 entity "entity" =  _ i:identifier _ al:("[" a:attributelist  "]" {return a})? _
 {
+  if (isKeyword(i)){
+    error("Keywords aren't allowed as entity names");
+  }
   var lOption = {};
   lOption["name"] = i;
   return merge (lOption, al);

--- a/src/script/parse/peg/mscgenparser.pegjs
+++ b/src/script/parse/peg/mscgenparser.pegjs
@@ -71,9 +71,12 @@
     function EntityNotDefinedError (pEntityName, pArc) {
         this.name = "EntityNotDefinedError";
         this.message = buildEntityNotDefinedMessage(pEntityName, pArc);
-        this.location = pArc.location;
-        this.location.start.line++;
-        this.location.end.line++;
+        /* istanbul ignore else  */
+        if(!!pArc.location){
+            this.location = pArc.location;
+            this.location.start.line++;
+            this.location.end.line++;        
+        }
     }
 
     function checkForUndeclaredEntities (pEntities, pArcLineList) {

--- a/src/script/parse/peg/msgennyparser.pegjs
+++ b/src/script/parse/peg/msgennyparser.pegjs
@@ -160,19 +160,19 @@ optionlist      = options:((o:option "," {return o})*
   return optionArray2Object(options);
 }
 
-option          = _ n:optionname _ "=" _
-                  v:(s:quotedstring {return s}
+option          = _ name:optionname _ "=" _
+                  value:(s:quotedstring {return s}
                      / i:number {return i.toString()}
                      / b:boolean {return b.toString()}) _
 {
-   var lOption = {};
-   n = n.toLowerCase();
-   if (n === "wordwraparcs"){
-      lOption[n] = flattenBoolean(v);
-   } else {
-      lOption[n]=v;
-   }
-   return lOption;
+  var lOption = {};
+  name = name.toLowerCase();
+  if (name === "wordwraparcs"){
+    lOption[name] = flattenBoolean(value);
+  } else {
+    lOption[name]=value;
+  }
+  return lOption;
 }
 optionname      = "hscale"i / "width"i / "arcgradient"i
                   /"wordwraparcs"i / "watermark"i
@@ -181,12 +181,12 @@ entitylist      = el:((e:entity "," {return e})* (e:entity ";" {return e}))
   el[0].push(el[1]);
   return el[0];
 }
-entity "entity" =  _ i:identifier _ l:(":" _ l:string _ {return l})?
+entity "entity" =  _ name:identifier _ label:(":" _ l:string _ {return l})?
 {
   var lEntity = {};
-  lEntity["name"] = i;
-  if (l) {
-    lEntity["label"] = l;
+  lEntity.name = name;
+  if (!!label) {
+    lEntity.label = label;
   }
   return lEntity;
 }
@@ -204,7 +204,7 @@ regulararc      = ra:((sa:singlearc {return sa})
                   label:(":" _ s:string _ {return s})?
 {
   if (label) {
-    ra["label"] = label;
+    ra.label = label;
   }
   return ra;
 }
@@ -223,7 +223,7 @@ spanarc         =
   {
     var retval = {kind: kind, from:from, to:to, arcs:arcs};
     if (label) {
-      retval["label"] = label;
+      retval.label = label;
     }
     return retval;
   })

--- a/src/script/parse/peg/xuparser.pegjs
+++ b/src/script/parse/peg/xuparser.pegjs
@@ -154,17 +154,17 @@ optionlist      = options:((o:option "," {return o})*
   return optionArray2Object(options);
 }
 
-option          = _ n:optionname _ "=" _
-                  v:(s:string {return s}
+option          = _ name:optionname _ "=" _
+                  value:(s:string {return s}
                      / i:number {return i.toString()}
                      / b:boolean {return b.toString()}) _
 {
    var lOption = {};
-   n = n.toLowerCase();
-   if (n === "wordwraparcs"){
-      lOption[n] = flattenBoolean(v);
+   name = name.toLowerCase();
+   if (name === "wordwraparcs"){
+      lOption[name] = flattenBoolean(value);
    } else {
-      lOption[n]=v;
+      lOption[name]=value;
    }
    return lOption;
 }
@@ -175,11 +175,9 @@ entitylist      = el:((e:entity "," {return e})* (e:entity ";" {return e}))
   el[0].push(el[1]);
   return el[0];
 }
-entity "entity" =  _ i:identifier _ al:("[" a:attributelist  "]" {return a})? _
+entity "entity" =  _ name:identifier _ attrList:("[" a:attributelist  "]" {return a})? _
 {
-  var lOption = {};
-  lOption["name"] = i;
-  return merge (lOption, al);
+  return merge ({name:name}, attrList);
 }
 arclist         = (a:arcline _ ";" {return a})+
 arcline         = al:((a:arc _ "," {return a})* (a:arc {return [a]}))
@@ -245,12 +243,12 @@ attributelist   = attributes:((a:attribute "," {return a})* (a:attribute {return
   return optionArray2Object(attributes);
 }
 
-attribute       = _ n:attributename _ "=" _ v:identifier _
+attribute       = _ name:attributename _ "=" _ value:identifier _
 {
   var lAttribute = {};
-  n = n.toLowerCase();
-  n = n.replace("colour", "color");
-  lAttribute[n] = v;
+  name = name.toLowerCase();
+  name = name.replace("colour", "color");
+  lAttribute[name] = value;
   return lAttribute
 }
 attributename  "attribute name"

--- a/src/script/parse/peg/xuparser.pegjs
+++ b/src/script/parse/peg/xuparser.pegjs
@@ -5,6 +5,13 @@
  * script is also a valid xù script
  * 
  * see https://github.com/sverweij/mscgen_js/wikum/xu.md for more information
+ * - mscgen cannot handle entity names that are also keywords
+ *   (box, abox, rbox, note, msc, hscale, width, arcgradient,
+ *   wordwraparcs, label, color, idurl, id, url,
+ *   linecolor, linecolour, textcolor, textcolour,
+ *   textbgcolor, textbgcolour, arclinecolor, arclinecolour,
+ *   arctextcolor, arctextcolour,arctextbgcolor, arctextbgcolour,
+ *   arcskip). This grammar does allow them. 
  */
 
 {

--- a/src/script/parse/peg/xuparser.pegjs
+++ b/src/script/parse/peg/xuparser.pegjs
@@ -49,9 +49,12 @@
     function EntityNotDefinedError (pEntityName, pArc) {
         this.name = "EntityNotDefinedError";
         this.message = buildEntityNotDefinedMessage(pEntityName, pArc);
-        this.location = pArc.location;
-        this.location.start.line++;
-        this.location.end.line++;
+        /* istanbul ignore else  */
+        if(!!pArc.location){
+            this.location = pArc.location;
+            this.location.start.line++;
+            this.location.end.line++;        
+        }
     }
 
     function checkForUndeclaredEntities (pEntities, pArcLineList) {

--- a/src/script/parse/xuparser.js
+++ b/src/script/parse/xuparser.js
@@ -124,14 +124,14 @@ define ([], function() {
           return merge (a, al);
         },
         peg$c46 = function(kind) {return {kind:kind}},
-        peg$c47 = function(from, kind, to) {return {kind: kind, from:from, to:to}},
+        peg$c47 = function(from, kind, to) {return {kind: kind, from:from, to:to, location:location()}},
         peg$c48 = "*",
         peg$c49 = { type: "literal", value: "*", description: "\"*\"" },
-        peg$c50 = function(kind, to) {return {kind:kind, from: "*", to:to}},
-        peg$c51 = function(from, kind) {return {kind:kind, from: from, to:"*"}},
+        peg$c50 = function(kind, to) {return {kind:kind, from: "*", to:to, location:location()}},
+        peg$c51 = function(from, kind) {return {kind:kind, from: from, to:"*", location:location()}},
         peg$c52 = function(from, kind, to, al) {return al},
         peg$c53 = function(from, kind, to, al, arclist) {
-            var lRetval = {kind: kind, from:from, to:to, arcs:arclist};
+            var lRetval = {kind: kind, from:from, to:to, location:location(), arcs:arclist};
             return merge (lRetval, al);
           },
         peg$c54 = "|||",
@@ -3149,11 +3149,18 @@ define ([], function() {
             });
         }
 
+        function buildEntityNotDefinedMessage(pEntityName, pArc){
+            return "Entity '" + pEntityName + "' in arc " +
+                   "'" + pArc.from + " " + pArc.kind + " " + pArc.to + "' " +
+                   "is not defined.";    
+        }
+
         function EntityNotDefinedError (pEntityName, pArc) {
-            this.message = "Entity '" + pEntityName + "' in arc ";
-            this.message += "'" + pArc.from + " " + pArc.kind + " " + pArc.to + "' ";
-            this.message += "is not defined.";
             this.name = "EntityNotDefinedError";
+            this.message = buildEntityNotDefinedMessage(pEntityName, pArc);
+            this.location = pArc.location;
+            this.location.start.line++;
+            this.location.end.line++;
         }
 
         function checkForUndeclaredEntities (pEntities, pArcLineList) {
@@ -3161,7 +3168,6 @@ define ([], function() {
                 pEntities = {};
                 pEntities.entities = [];
             }
-
             if (pArcLineList && pArcLineList.arcs) {
                 pArcLineList.arcs.forEach(function(pArcLine) {
                     pArcLine.forEach(function(pArc) {
@@ -3170,6 +3176,12 @@ define ([], function() {
                         }
                         if (pArc.to && !entityExists (pEntities, pArc.to)) {
                             throw new EntityNotDefinedError(pArc.to, pArc);
+                        }
+                        if (!!pArc.location) {
+                            delete pArc.location;
+                        }
+                        if (!!pArc.arcs){
+                            checkForUndeclaredEntities(pEntities, pArc);
                         }
                     });
                 });
@@ -3205,7 +3217,7 @@ define ([], function() {
             return {
                 "extendedOptions" : lHasExtendedOptions,
                 "extendedArcTypes": lHasExtendedArcTypes,
-                "extendedFeatures":  lHasExtendedOptions||lHasExtendedArcTypes
+                "extendedFeatures": lHasExtendedOptions||lHasExtendedArcTypes
             }
         }
 

--- a/src/script/parse/xuparser.js
+++ b/src/script/parse/xuparser.js
@@ -73,16 +73,16 @@ define ([], function() {
         },
         peg$c16 = "=",
         peg$c17 = { type: "literal", value: "=", description: "\"=\"" },
-        peg$c18 = function(n, s) {return s},
-        peg$c19 = function(n, i) {return i.toString()},
-        peg$c20 = function(n, b) {return b.toString()},
-        peg$c21 = function(n, v) {
+        peg$c18 = function(name, s) {return s},
+        peg$c19 = function(name, i) {return i.toString()},
+        peg$c20 = function(name, b) {return b.toString()},
+        peg$c21 = function(name, value) {
            var lOption = {};
-           n = n.toLowerCase();
-           if (n === "wordwraparcs"){
-              lOption[n] = flattenBoolean(v);
+           name = name.toLowerCase();
+           if (name === "wordwraparcs"){
+              lOption[name] = flattenBoolean(value);
            } else {
-              lOption[n]=v;
+              lOption[name]=value;
            }
            return lOption;
         },
@@ -106,11 +106,9 @@ define ([], function() {
         peg$c36 = { type: "literal", value: "[", description: "\"[\"" },
         peg$c37 = "]",
         peg$c38 = { type: "literal", value: "]", description: "\"]\"" },
-        peg$c39 = function(i, a) {return a},
-        peg$c40 = function(i, al) {
-          var lOption = {};
-          lOption["name"] = i;
-          return merge (lOption, al);
+        peg$c39 = function(name, a) {return a},
+        peg$c40 = function(name, attrList) {
+          return merge ({name:name}, attrList);
         },
         peg$c41 = function(a) {return a},
         peg$c42 = function(a) {return [a]},
@@ -229,11 +227,11 @@ define ([], function() {
         peg$c146 = function(attributes) {
           return optionArray2Object(attributes);
         },
-        peg$c147 = function(n, v) {
+        peg$c147 = function(name, value) {
           var lAttribute = {};
-          n = n.toLowerCase();
-          n = n.replace("colour", "color");
-          lAttribute[n] = v;
+          name = name.toLowerCase();
+          name = name.replace("colour", "color");
+          lAttribute[name] = value;
           return lAttribute
         },
         peg$c148 = { type: "other", description: "attribute name" },

--- a/src/script/parse/xuparser.js
+++ b/src/script/parse/xuparser.js
@@ -3158,9 +3158,12 @@ define ([], function() {
         function EntityNotDefinedError (pEntityName, pArc) {
             this.name = "EntityNotDefinedError";
             this.message = buildEntityNotDefinedMessage(pEntityName, pArc);
-            this.location = pArc.location;
-            this.location.start.line++;
-            this.location.end.line++;
+            /* istanbul ignore else  */
+            if(!!pArc.location){
+                this.location = pArc.location;
+                this.location.start.line++;
+                this.location.end.line++;        
+            }
         }
 
         function checkForUndeclaredEntities (pEntities, pArcLineList) {

--- a/src/script/parse/xuparser_node.js
+++ b/src/script/parse/xuparser_node.js
@@ -3158,9 +3158,12 @@ module.exports = (function() {
         function EntityNotDefinedError (pEntityName, pArc) {
             this.name = "EntityNotDefinedError";
             this.message = buildEntityNotDefinedMessage(pEntityName, pArc);
-            this.location = pArc.location;
-            this.location.start.line++;
-            this.location.end.line++;
+            /* istanbul ignore else  */
+            if(!!pArc.location){
+                this.location = pArc.location;
+                this.location.start.line++;
+                this.location.end.line++;        
+            }
         }
 
         function checkForUndeclaredEntities (pEntities, pArcLineList) {

--- a/src/script/parse/xuparser_node.js
+++ b/src/script/parse/xuparser_node.js
@@ -73,16 +73,16 @@ module.exports = (function() {
         },
         peg$c16 = "=",
         peg$c17 = { type: "literal", value: "=", description: "\"=\"" },
-        peg$c18 = function(n, s) {return s},
-        peg$c19 = function(n, i) {return i.toString()},
-        peg$c20 = function(n, b) {return b.toString()},
-        peg$c21 = function(n, v) {
+        peg$c18 = function(name, s) {return s},
+        peg$c19 = function(name, i) {return i.toString()},
+        peg$c20 = function(name, b) {return b.toString()},
+        peg$c21 = function(name, value) {
            var lOption = {};
-           n = n.toLowerCase();
-           if (n === "wordwraparcs"){
-              lOption[n] = flattenBoolean(v);
+           name = name.toLowerCase();
+           if (name === "wordwraparcs"){
+              lOption[name] = flattenBoolean(value);
            } else {
-              lOption[n]=v;
+              lOption[name]=value;
            }
            return lOption;
         },
@@ -106,11 +106,9 @@ module.exports = (function() {
         peg$c36 = { type: "literal", value: "[", description: "\"[\"" },
         peg$c37 = "]",
         peg$c38 = { type: "literal", value: "]", description: "\"]\"" },
-        peg$c39 = function(i, a) {return a},
-        peg$c40 = function(i, al) {
-          var lOption = {};
-          lOption["name"] = i;
-          return merge (lOption, al);
+        peg$c39 = function(name, a) {return a},
+        peg$c40 = function(name, attrList) {
+          return merge ({name:name}, attrList);
         },
         peg$c41 = function(a) {return a},
         peg$c42 = function(a) {return [a]},
@@ -229,11 +227,11 @@ module.exports = (function() {
         peg$c146 = function(attributes) {
           return optionArray2Object(attributes);
         },
-        peg$c147 = function(n, v) {
+        peg$c147 = function(name, value) {
           var lAttribute = {};
-          n = n.toLowerCase();
-          n = n.replace("colour", "color");
-          lAttribute[n] = v;
+          name = name.toLowerCase();
+          name = name.replace("colour", "color");
+          lAttribute[name] = value;
           return lAttribute
         },
         peg$c148 = { type: "other", description: "attribute name" },

--- a/src/script/test/parse/t_mscgenparser_node.js
+++ b/src/script/test/parse/t_mscgenparser_node.js
@@ -130,6 +130,9 @@ describe('parse/mscgenparser', function() {
         it ("should complain about an undeclared entity in a to", function(){
             tst.assertSyntaxError("msc{a,b,c;b=>f;}", parser, "EntityNotDefinedError");
         });
+        it("should throw a SyntaxError when a keyword is used for an entityt name", function(){
+            tst.assertSyntaxError("msc{a,note,b,c; a => note;}", parser);
+        });
     });
 
     describe('#parse() - file based tests', function() {

--- a/src/script/test/parse/t_xuparser_node.js
+++ b/src/script/test/parse/t_xuparser_node.js
@@ -9,7 +9,7 @@ describe('parse/xuparser', function() {
 
         it('should render a simple AST', function() {
             var lAST = parser.parse('msc { a,"b space"; a => "b space" [label="a simple script"];}');
-            expect(lAST).to.deep.equal(fix.astSimple);
+            expect(lAST).to.be.deep.equal(fix.astSimple);
         });
         it('should ignore c++ style one line comments', function() {
             var lAST = parser.parse('msc { a,"b space"; a => "b space" [label="a simple script"];}//ignored');
@@ -205,6 +205,9 @@ describe('parse/xuparser', function() {
         });
         it("should throw a SyntaxError on a missing a closing bracket after a valid option", function() {
             tst.assertSyntaxError('msc {a,b; a loop b [label="brackets missing"', parser);
+        });
+        it("should throw an EntityNotDefinedError on a missing entity somewhere deeply nested", function() {
+            tst.assertSyntaxError('msc {a,b; a loop b {c => b;};}', parser, "EntityNotDefinedError");
         });
     });
 });

--- a/src/script/test/testutensils.js
+++ b/src/script/test/testutensils.js
@@ -74,9 +74,8 @@ return {
             pErrorType = "SyntaxError";
         }
         try {
-            var lAST = pParser.parse(pProgram);
             var lStillRan = false;
-            if (lAST) {
+            if (pParser.parse(pProgram)) {
                 lStillRan = true;
             }
             expect(lStillRan).to.equal(false);


### PR DESCRIPTION
…d messages in xu and mscgen parsers

Also 
- fixes a bug where undefined entities within inline expression bodies were not detected
- adds a check to the mscgen parser to disallow keywords as entity names - they will cause problems in the original mscgen. Still allowed in xu and msgenny, though.