### PR TITLE
Embedding: read external msc scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mscgen_js",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Turns text into sequence charts. A faithfull implementation of the mscgen sequence chart language in javascript.",
   "dependencies": {
     "almond": "0.3.1",

--- a/src/embed.html
+++ b/src/embed.html
@@ -55,6 +55,11 @@
 
         <title>mscgen_js - embed</title>
         <link rel="stylesheet" href="./style/doc.css?{{commit}}" type="text/css" media="screen, print">
+        <script>
+        var mscgen_js_config = {
+            loadFromSrcAttribute: true
+        };
+        </script>
         <script src="mscgen-inpage.js?{{commit}}" defer></script>
         <script>
         (function(i, s, o, g, r, a, m) {
@@ -230,6 +235,46 @@ msc {
         <mark>clickURL: "https://your.host/pathtointerpreter/"</mark>
     };
 &lt;/script></pre></p></li>
+        </ul>
+        <h2 id="loading-from-separate-files">Loading charts from separate files</h2>
+        <p>
+            If you want to maintain your sequence chart sources separate from
+            your html, you can. By default this is off. 
+        </p>
+        <ul>
+            <li>
+                To <strong>enable</strong> it, add 
+                a <code>loadFromSrcAttribute</code> with the value <code>true</code>
+                to the <code>mscgen_js_config</code> object:<pre class="code">&lt;script>
+        var mscgen_js_config = {
+            <mark>loadFromSrcAttribute: true</mark>
+        };
+    &lt;/script></pre></li>
+            <li>
+                To <strong>use</strong> it, mention the URL where to find the sequence chart source
+                in a <code>data-src</code> attribute:
+                <pre class="code">&lt;pre class="mscgen_js" 
+     <mark>data-src="./samples/test21a_unicode_serious.msgenny"</mark>
+     data-language="msgenny">&lt;/pre></pre>
+            </li>
+
+            <li>
+                <strong>Result</strong> when successfull:
+                <div class="mscgen_js"
+                     data-src="./samples/test21a_unicode_serious.msgenny"
+                     data-language="msgenny">
+                 </div>
+            </li>
+            <li>Error handling:
+                <ul>
+                    <li>If the tag contains a <code>data-src</code> attribute,
+                        the embedding script will only use the contents of the
+                        chart on the other end of the URL, but it will will
+                        ignore the tag body.</li>
+                    <li>If the embedding script cannot load the content, it will
+                        insert an error message.</li>
+                </ul>
+            </li>
         </ul>
         <h2 id="supported-browsers">Supported browsers: most</h2>
         <p>

--- a/src/embed.html
+++ b/src/embed.html
@@ -245,25 +245,25 @@ msc {
             <li>
                 To <strong>enable</strong> it, add 
                 a <code>loadFromSrcAttribute</code> with the value <code>true</code>
-                to the <code>mscgen_js_config</code> object:<pre class="code">&lt;script>
+                to the <code>mscgen_js_config</code> object:<p><pre class="code">&lt;script>
         var mscgen_js_config = {
             <mark>loadFromSrcAttribute: true</mark>
         };
-    &lt;/script></pre></li>
+    &lt;/script></pre></p></li>
             <li>
                 To <strong>use</strong> it, mention the URL where to find the sequence chart source
                 in a <code>data-src</code> attribute:
-                <pre class="code">&lt;pre class="mscgen_js" 
+                <p><pre class="code">&lt;pre class="mscgen_js" 
      <mark>data-src="./samples/test21a_unicode_serious.msgenny"</mark>
-     data-language="msgenny">&lt;/pre></pre>
+     data-language="msgenny">&lt;/pre></pre></p>
             </li>
 
             <li>
                 <strong>Result</strong> when successfull:
-                <div class="mscgen_js"
+                <p><div class="mscgen_js"
                      data-src="./samples/test21a_unicode_serious.msgenny"
                      data-language="msgenny">
-                 </div>
+                 </div></p>
             </li>
             <li>Error handling:
                 <ul>

--- a/src/embed.html
+++ b/src/embed.html
@@ -269,10 +269,10 @@ msc {
                 <ul>
                     <li>If the tag contains a <code>data-src</code> attribute,
                         the embedding script will only use the contents of the
-                        chart on the other end of the URL, but it will will
-                        ignore the tag body.</li>
+                        chart on the other end of the URL. It will
+                        ignore everything in the tag body.</li>
                     <li>If the embedding script cannot load the content, it will
-                        insert an error message.</li>
+                        insert an error message telling you so.</li>
                 </ul>
             </li>
         </ul>

--- a/src/jsdependencies.mk
+++ b/src/jsdependencies.mk
@@ -7,8 +7,9 @@ src/script/mscgen-inpage.js: \
 	src/script/parse/xuparser.js \
 	src/script/render/graphics/renderast.js \
 	src/script/ui/embedding/config.js \
-	src/script/ui/utl/exporter.js \
-	src/script/utl/utensils.js
+	src/script/ui/embedding/error-rendering.js \
+	src/script/ui/utl/domutl.js \
+	src/script/ui/utl/exporter.js
 
 src/script/mscgen-interpreter.js: \
 	src/script/ui/interpreter/editor-events.js \
@@ -252,8 +253,7 @@ src/script/test/parse/t_xuparser_node.js: \
 	src/script/test/testutensils.js
 
 src/script/test/render/graphics/t_markermanager.js: \
-	src/script/render/graphics/markermanager.js \
-	src/script/test/testutensils.js
+	src/script/render/graphics/markermanager.js
 
 src/script/test/render/graphics/t_renderast.js: \
 	src/script/render/graphics/renderast.js \
@@ -276,8 +276,7 @@ src/script/test/render/text/t_ast2doxygen.js: \
 src/script/test/render/text/t_ast2mscgen.js: \
 	src/script/parse/mscgenparser_node.js \
 	src/script/render/text/ast2mscgen.js \
-	src/script/test/astfixtures.js \
-	src/script/test/testutensils.js
+	src/script/test/astfixtures.js
 
 src/script/test/render/text/t_ast2msgenny.js: \
 	src/script/render/text/ast2msgenny.js \
@@ -287,26 +286,25 @@ src/script/test/render/text/t_ast2msgenny.js: \
 src/script/test/render/text/t_ast2xu.js: \
 	src/script/parse/xuparser_node.js \
 	src/script/render/text/ast2xu.js \
-	src/script/test/astfixtures.js \
-	src/script/test/testutensils.js
+	src/script/test/astfixtures.js
 
 src/script/test/render/text/t_colorize.js: \
 	src/script/render/text/colorize.js \
 	src/script/test/astfixtures.js \
-	src/script/test/testutensils.js \
 	src/script/utl/utensils.js
 
 src/script/test/render/text/t_flatten.js: \
 	src/script/render/text/flatten.js \
-	src/script/test/astfixtures.js \
-	src/script/test/testutensils.js
+	src/script/test/astfixtures.js
 
 src/script/test/render/text/t_textutensils.js: \
 	src/script/render/text/textutensils.js
 
 src/script/test/ui/embedding/t_config.js: \
-	src/script/test/testutensils.js \
 	src/script/ui/embedding/config.js
+
+src/script/test/ui/embedding/t_error-rendering.js: \
+	src/script/ui/embedding/error-rendering.js
 
 src/script/test/ui/utl/t_exporter.js: \
 	src/script/ui/utl/exporter.js
@@ -315,7 +313,6 @@ src/script/test/ui/utl/t_maps.js: \
 	src/script/ui/utl/maps.js
 
 src/script/test/ui/utl/t_paramslikker.js: \
-	src/script/test/testutensils.js \
 	src/script/ui/utl/paramslikker.js
 
 src/script/test/ui/utl/t_store.js: \
@@ -348,6 +345,8 @@ EMBED_JS_SOURCES=src/script/mscgen-inpage.js \
 	src/script/render/text/flatten.js \
 	src/script/render/text/textutensils.js \
 	src/script/ui/embedding/config.js \
+	src/script/ui/embedding/error-rendering.js \
+	src/script/ui/utl/domutl.js \
 	src/script/ui/utl/exporter.js \
 	src/script/ui/utl/paramslikker.js \
 	src/script/utl/utensils.js

--- a/src/samples/embedexternal.html
+++ b/src/samples/embedexternal.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html;charset=utf-8" >
+        <script>
+          var mscgen_js_config = {
+            clickable: true,
+            clickURL: "http://localhost:8666/",
+            loadFromSrcAttribute: true
+          }
+        </script>
+        <script data-main="../script/mscgen-inpage.js"
+        src="../lib/require.js" defer></script>
+        
+    </head>
+    <body>
+        <h2>Read from an external file</h2>
+        <mscgen src="./test21_unicode_colored.mscin"></mscgen>
+        
+        <h2>Read from a non-existing external file</h2>
+        <mscgen src="thisfiledoesnotexist.mscin"></mscgen>
+        
+        <h2>Embedded in the page</h2>
+        <pre class="mscgen_js">
+            msc {
+                a,b,c;
+                b => * [label="hello world"];
+                a >> b [label="hello b"],
+                c >> b [label="hello b"];
+            }
+        </pre>
+        
+        <h2>Embedded in the page and a src attribute</h2>
+        <p>
+            The stuff in the src attribute wins. In
+            this case means we see a cross word puzzle.
+        </p>
+        <mscgen src="./test21a_unicode_serious.msgenny" data-language="msgenny">
+            msc {
+                a,b,c;
+                b => * [label="hello world"];
+                a >> b [label="hello b"],
+                c >> b [label="hello b"];
+            }
+        </mscgen>
+    </body>
+</html>

--- a/src/samples/embedexternal.html
+++ b/src/samples/embedexternal.html
@@ -9,29 +9,28 @@
             loadFromSrcAttribute: true
           }
         </script>
-        <script src="/mscgen-inpage.js" defer></script>
+        <script src="../mscgen-inpage.js" defer></script>
         
     </head>
     <body>
         <h2>Read from an external file</h2>
-        <mscgen src="./test21_unicode_colored.mscin"></mscgen>
+        <div class="mscgen_js" data-src="./test21_unicode_colored.mscin"></div>
         
         <h2>Read from a non-existing external file</h2>
         <p>
             As we passed the non-existing file <em>thisfiledoesnotexist.mscin</em>,
             we would expect an error message reflecting this...
         </p>
-        <mscgen src="thisfiledoesnotexist.mscin"></mscgen>
+        <pre class="mscgen_js" data-src="thisfiledoesnotexist.mscin"></pre>
         
         <h2>Embedded in the page</h2>
         <p>Should still work</p>
-        <pre class="mscgen_js">
-            msc {
-                a,b,c;
-                b => * [label="hello world"];
-                a >> b [label="hello b"],
-                c >> b [label="hello b"];
-            }
+        <pre class="code mscgen mscgen_js">msc {
+    a,b,c;
+    b => * [label="hello world"];
+    a >> b [label="hello b"],
+    c >> b [label="hello b"];
+}
         </pre>
         
         <h2>Embedded in the page and a src attribute</h2>
@@ -40,12 +39,11 @@
             this case means we should a unicode conversation.
             And not the letters a, b and c introducing each other.
         </p>
-        <mscgen src="./test21a_unicode_serious.msgenny" data-language="msgenny">
-        a, b, c;
+        <pre class="code msgenny mscgen_js" data-src="./test21a_unicode_serious.msgenny" data-language="msgenny">a, b, c;
 
-        b => * : hello world;
-        a >> b : hello b,
-        c >> b : hello b;
-        </mscgen>
+b => * : hello world;
+a >> b : hello b,
+c >> b : hello b;
+        </pre>
     </body>
 </html>

--- a/src/samples/embedexternal.html
+++ b/src/samples/embedexternal.html
@@ -5,7 +5,7 @@
         <script>
           var mscgen_js_config = {
             clickable: true,
-            clickURL: "./",
+            clickURL: "../",
             loadFromSrcAttribute: true
           }
         </script>

--- a/src/samples/embedexternal.html
+++ b/src/samples/embedexternal.html
@@ -5,12 +5,11 @@
         <script>
           var mscgen_js_config = {
             clickable: true,
-            clickURL: "http://localhost:8666/",
+            clickURL: "./",
             loadFromSrcAttribute: true
           }
         </script>
-        <script data-main="../script/mscgen-inpage.js"
-        src="../lib/require.js" defer></script>
+        <script src="/mscgen-inpage.js" defer></script>
         
     </head>
     <body>
@@ -18,9 +17,14 @@
         <mscgen src="./test21_unicode_colored.mscin"></mscgen>
         
         <h2>Read from a non-existing external file</h2>
+        <p>
+            As we passed the non-existing file <em>thisfiledoesnotexist.mscin</em>,
+            we would expect an error message reflecting this...
+        </p>
         <mscgen src="thisfiledoesnotexist.mscin"></mscgen>
         
         <h2>Embedded in the page</h2>
+        <p>Should still work</p>
         <pre class="mscgen_js">
             msc {
                 a,b,c;
@@ -33,15 +37,15 @@
         <h2>Embedded in the page and a src attribute</h2>
         <p>
             The stuff in the src attribute wins. In
-            this case means we see a cross word puzzle.
+            this case means we should a unicode conversation.
+            And not the letters a, b and c introducing each other.
         </p>
         <mscgen src="./test21a_unicode_serious.msgenny" data-language="msgenny">
-            msc {
-                a,b,c;
-                b => * [label="hello world"];
-                a >> b [label="hello b"],
-                c >> b [label="hello b"];
-            }
+        a, b, c;
+
+        b => * : hello world;
+        a >> b : hello b,
+        c >> b : hello b;
         </mscgen>
     </body>
 </html>

--- a/src/script/README.md
+++ b/src/script/README.md
@@ -62,7 +62,7 @@ The controller for the interpreter UI is less trivial.
 ## Testing
 :page_with_curl: code in [test/](test)
 
-About 280 automated tests (and counting) make sure we can refactor most of
+About 300 automated tests (and counting) make sure we can refactor most of
 the back end code (parsing and rendering) safely.
 
 The ui controller tests are inherently harder to test automated. This

--- a/src/script/mscgen-inpage.js
+++ b/src/script/mscgen-inpage.js
@@ -3,11 +3,11 @@
 require(["parse/xuparser",
          "parse/msgennyparser",
          "render/graphics/renderast",
-         "utl/utensils",
          "ui/utl/exporter",
          "ui/embedding/config",
+         "ui/embedding/error-rendering",
          "ui/utl/domutl"],
-        function(mscparser, msgennyparser, mscrender, _, exp, conf, $) {
+        function(mscparser, msgennyparser, mscrender, exp, conf, err, $) {
     "use strict";
 
     start();
@@ -16,19 +16,6 @@ require(["parse/xuparser",
         var lClassElements = document.getElementsByClassName("mscgen_js");
         renderElementArray(lClassElements, 0);
         renderElementArray(document.getElementsByTagName("mscgen"), lClassElements.length);
-    }
-
-    function formatLine(pLine, pLineNo){
-        return _.formatNumber(pLineNo, 3) + " " + pLine;
-    }
-
-    function underlineCol(pLine, pCol){
-        return pLine.split("").reduce(function(pPrev, pChar, pIndex){
-            if (pIndex === pCol) {
-                return pPrev + "<span style='text-decoration:underline'>" + _.deHTMLize(pChar) + "</span>";
-            }
-            return pPrev + _.deHTMLize(pChar);
-        }, "");
     }
 
     function renderElementArray(pMscGenElements, pStartIdAt){
@@ -41,19 +28,6 @@ require(["parse/xuparser",
         if (!pElement.hasAttribute('data-renderedby')) {
             renderElement(pElement, pIndex);
         }
-    }
-
-    function renderError(pSource, pErrorLocation, pMessage){
-        var lErrorIntro = !!pErrorLocation ?
-            "<pre><div style='color: red'># ERROR on line " + pErrorLocation.start.line + ", column " + pErrorLocation.start.column + " - " + pMessage + "</div>" :
-            "<pre><div style='color: red'># ERROR " + pMessage + "</div>";
-
-        return pSource.split('\n').reduce(function(pPrev, pLine, pIndex) {
-            if (!!pErrorLocation && pIndex === (pErrorLocation.start.line - 1)) {
-                return pPrev + "<mark>" + formatLine(underlineCol(pLine, pErrorLocation.start.column - 1), pIndex + 1) + '\n' + "</mark>";
-            }
-            return pPrev + _.deHTMLize(formatLine(pLine, pIndex + 1)) + '\n';
-        }, lErrorIntro) + "</pre>";
     }
 
     function renderElementError(pElement, pString) {
@@ -102,7 +76,7 @@ require(["parse/xuparser",
         if (lAST.entities) {
             render(lAST, pElement.id, pSource, lLanguage);
         } else {
-            pElement.innerHTML = renderError(pSource, lAST.location, lAST.message);
+            pElement.innerHTML = err.renderError(pSource, lAST.location, lAST.message);
         }
     }
 

--- a/src/script/mscgen-inpage.js
+++ b/src/script/mscgen-inpage.js
@@ -56,6 +56,12 @@ require(["parse/xuparser",
         }, lErrorIntro) + "</pre>";
     }
 
+    function renderElementError(pElement, pString) {
+        pElement.innerHTML =
+            "<div style='color: red'>" +
+            pString + "</div>";
+    }
+
     function renderElement (pElement, pIndex){
         setElementId(pElement, pIndex);
         pElement.setAttribute("data-renderedby", "mscgen_js");
@@ -67,12 +73,24 @@ require(["parse/xuparser",
                     parseAndRender(pElement, pEvent.target.response);
                 },
                 function onError() {
-                    pElement.innerHTML =
-                          "<code><div style='color: red'>" +
-                          "ERROR: Could not find or open the URL '" +
-                          pElement.getAttribute("src") +
-                          "' specified in the <code>data-src</code> attribute.</div></code>";
+                    renderElementError(
+                        pElement,
+                        "ERROR: Could not find or open the URL '" +
+                        pElement.getAttribute("data-src") +
+                        "' specified in the <code>data-src</code> attribute."
+                    );
                 }
+            );
+        } else if (!conf.getConfig().loadFromSrcAttribute && !!pElement.getAttribute("data-src")){
+            renderElementError(
+                pElement,
+                "ERROR: Won't load the chart specified in <code>data-src='" +
+                pElement.getAttribute("data-src") + "'</code>, "+
+                "because loading from separate files is switched off in the " +
+                "mscgen_js configuration." +
+                "<br><br>See " +
+                "<a href='https://sverweij.github.io/mscgen_js/embed.html#loading-from-separate-files'>Loading charts from separate files</a>" +
+                " in the mscgen_js embedding guide how to enable it."
             );
         } else {
             parseAndRender(pElement, pElement.textContent);

--- a/src/script/mscgen-inpage.js
+++ b/src/script/mscgen-inpage.js
@@ -25,9 +25,9 @@ require(["parse/xuparser",
     function underlineCol(pLine, pCol){
         return pLine.split("").reduce(function(pPrev, pChar, pIndex){
             if (pIndex === pCol) {
-                return pPrev + "<span style='text-decoration:underline'>" + pChar + "</span>";
+                return pPrev + "<span style='text-decoration:underline'>" + _.deHTMLize(pChar) + "</span>";
             }
-            return pPrev + pChar;
+            return pPrev + _.deHTMLize(pChar);
         }, "");
     }
 
@@ -52,14 +52,12 @@ require(["parse/xuparser",
             if (!!pErrorLocation && pIndex === (pErrorLocation.start.line - 1)) {
                 return pPrev + "<mark>" + formatLine(underlineCol(pLine, pErrorLocation.start.column - 1), pIndex + 1) + '\n' + "</mark>";
             }
-            return pPrev + formatLine(pLine, pIndex + 1) + '\n';
+            return pPrev + _.deHTMLize(formatLine(pLine, pIndex + 1)) + '\n';
         }, lErrorIntro) + "</pre>";
     }
 
     function renderElementError(pElement, pString) {
-        pElement.innerHTML =
-            "<div style='color: red'>" +
-            pString + "</div>";
+        pElement.innerHTML = "<div style='color: red'>" + pString + "</div>";
     }
 
     function renderElement (pElement, pIndex){

--- a/src/script/mscgen-inpage.js
+++ b/src/script/mscgen-inpage.js
@@ -60,9 +60,9 @@ require(["parse/xuparser",
         setElementId(pElement, pIndex);
         pElement.setAttribute("data-renderedby", "mscgen_js");
 
-        if (conf.getConfig().loadFromSrcAttribute && !!pElement.getAttribute("src")){
+        if (conf.getConfig().loadFromSrcAttribute && !!pElement.getAttribute("data-src")){
             $.ajax(
-                pElement.getAttribute("src"),
+                pElement.getAttribute("data-src"),
                 function onSuccess(pEvent) {
                     parseAndRender(pElement, pEvent.target.response);
                 },

--- a/src/script/mscgen-inpage.js
+++ b/src/script/mscgen-inpage.js
@@ -65,9 +65,9 @@ require(["parse/xuparser",
                 pElement.getAttribute("src"),
                 function onSuccess(pEvent) {
                     parseAndRender(pElement, pEvent.target.response);
-                }, 
+                },
                 function onError() {
-                    pElement.innerHTML = 
+                    pElement.innerHTML =
                           "<code><div style='color: red'>" +
                           "ERROR: Could not find or open the URL '" +
                           pElement.getAttribute("src") +

--- a/src/script/mscgen-inpage.js
+++ b/src/script/mscgen-inpage.js
@@ -71,7 +71,7 @@ require(["parse/xuparser",
                           "<code><div style='color: red'>" +
                           "ERROR: Could not find or open the URL '" +
                           pElement.getAttribute("src") +
-                          "' specified in the <code>src</code> attribute.</div></code>";
+                          "' specified in the <code>data-src</code> attribute.</div></code>";
                 }
             );
         } else {

--- a/src/script/test/ui/embedding/t_config.js
+++ b/src/script/test/ui/embedding/t_config.js
@@ -11,6 +11,7 @@ describe('ui/embedding/embed-config', function() {
                 parentElementPrefix : "mscgen_js-parent_",
                 clickable : false,
                 clickURL : "https://sverweij.github.io/mscgen_js/",
+                loadFromSrcAttribute: false
             });
         });
 
@@ -25,6 +26,7 @@ describe('ui/embedding/embed-config', function() {
                 parentElementPrefix : "mscgen_js-parent_",
                 clickable : true,
                 clickURL : "http://localhost/",
+                loadFromSrcAttribute: false
             });
         });
     });

--- a/src/script/test/ui/embedding/t_error-rendering.js
+++ b/src/script/test/ui/embedding/t_error-rendering.js
@@ -1,0 +1,68 @@
+/* jshint esnext:true */
+var err    = require("../../../ui/embedding/error-rendering");
+var expect = require("chai").expect;
+var assert = require("assert");
+
+describe('ui/embedding/error-rendering', function() {
+    describe('#renderError', function() {
+        it('should render error and source without underline when error location not provided', function() {
+            expect(err.renderError("Just a source\nwith two lines", undefined, "just a message")).to.equal(
+                "<pre><div style='color: red'># ERROR " + "just a message" + "</div>  1 Just a source\n  2 with two lines\n</pre>"
+            );
+        });
+
+        it('should render error and source with underline when error location provided', function() {
+            var lErrorLocation = {
+                start: {
+                    line: 2,
+                    column: 6
+                }
+            };
+            expect(err.renderError("Just a source\nwith two lines", lErrorLocation, "just a message")).to.equal(
+                "<pre><div style='color: red'># ERROR " + "on line 2, column 6 - just a message" + "</div>  1 Just a source\n<mark>  2 with <span style='text-decoration:underline'>t</span>wo lines\n</mark></pre>"
+            );
+        });
+    });
+
+    describe('#deHTMLize() - ', function(){
+        it(
+            "replaces < with &lt;",
+            () => assert.equal("&lt;", err.deHTMLize("<"))
+        );
+        it(
+            "replaces all < with &lt;",
+            () => assert.equal(
+                "&lt;bla>hello&lt;/bla>",
+                err.deHTMLize("<bla>hello</bla>")
+            )
+        );
+        it(
+            "leaves strings without < alone",
+            () => assert.equal(
+                "In Dutch, Huey, Louis and Dewy translate => Kwik, Kwek en Kwak",
+                err.deHTMLize(
+                    "In Dutch, Huey, Louis and Dewy translate => Kwik, Kwek en Kwak"
+                )
+            )
+        );
+    });
+
+    describe('#formatNumber() - ', function() {
+        it('puts two spaces in front of a single digit on max width 3', function() {
+            assert.equal(err.formatNumber(7, 3), "  7");
+        });
+        it('puts no spaces in front of a single digit on max width 1', function() {
+            assert.equal(err.formatNumber(7, 1), "7");
+        });
+        it('puts no spaces in front of a single digit on max width 0', function() {
+            assert.equal(err.formatNumber(7, 0), "7");
+        });
+        it('puts no spaces in front of a single digit on max width < 0', function() {
+            assert.equal(err.formatNumber(7, -8), "7");
+        });
+        it('puts no spaces in front of a three digit number on max width 3', function() {
+            assert.equal(err.formatNumber(481, 3), "481");
+        });
+    });
+
+});

--- a/src/script/test/utl/t_utensils.js
+++ b/src/script/test/utl/t_utensils.js
@@ -1,4 +1,3 @@
-/* jshint esnext:true */
 var assert = require("assert");
 var _ = require("../../utl/utensils");
 
@@ -19,44 +18,4 @@ describe('utl/utensils', function() {
         });
     });
 
-    describe('#deHTMLize() - ', function(){
-        it(
-            "replaces < with &lt;",
-            () => assert.equal("&lt;", _.deHTMLize("<"))
-        );
-        it(
-            "replaces all < with &lt;",
-            () => assert.equal(
-                "&lt;bla>hello&lt;/bla>",
-                _.deHTMLize("<bla>hello</bla>")
-            )
-        );
-        it(
-            "leaves strings without < alone",
-            () => assert.equal(
-                "In Dutch, Huey, Louis and Dewy translate => Kwik, Kwek en Kwak",
-                _.deHTMLize(
-                    "In Dutch, Huey, Louis and Dewy translate => Kwik, Kwek en Kwak"
-                )
-            )
-        );
-    });
-
-    describe('#formatNumber() - ', function() {
-        it('puts two spaces in front of a single digit on max width 3', function() {
-            assert.equal(_.formatNumber(7, 3), "  7");
-        });
-        it('puts no spaces in front of a single digit on max width 1', function() {
-            assert.equal(_.formatNumber(7, 1), "7");
-        });
-        it('puts no spaces in front of a single digit on max width 0', function() {
-            assert.equal(_.formatNumber(7, 0), "7");
-        });
-        it('puts no spaces in front of a single digit on max width < 0', function() {
-            assert.equal(_.formatNumber(7, -8), "7");
-        });
-        it('puts no spaces in front of a three digit number on max width 3', function() {
-            assert.equal(_.formatNumber(481, 3), "481");
-        });
-    });
 });

--- a/src/script/test/utl/t_utensils.js
+++ b/src/script/test/utl/t_utensils.js
@@ -1,3 +1,4 @@
+/* jshint esnext:true */
 var assert = require("assert");
 var _ = require("../../utl/utensils");
 
@@ -16,6 +17,29 @@ describe('utl/utensils', function() {
         it('sanitize booleanesque', function() {
             assert.equal(false, _.sanitizeBooleanesque("0"));
         });
+    });
+    
+    describe('#deHTMLize() - ', function(){
+        it(
+            "replaces < with &lt;", 
+            () => assert.equal("&lt;", _.deHTMLize("<"))
+        );
+        it(
+            "replaces all < with &lt;", 
+            () => assert.equal(
+                "&lt;bla>hello&lt;/bla>",
+                _.deHTMLize("<bla>hello</bla>")
+            )
+        );
+        it(
+            "leaves strings without < alone", 
+            () => assert.equal(
+                "In Dutch, Huey, Louis and Dewy translate => Kwik, Kwek en Kwak",
+                _.deHTMLize(
+                    "In Dutch, Huey, Louis and Dewy translate => Kwik, Kwek en Kwak"
+                )
+            )
+        );
     });
 
     describe('#formatNumber() - ', function() {

--- a/src/script/test/utl/t_utensils.js
+++ b/src/script/test/utl/t_utensils.js
@@ -18,21 +18,21 @@ describe('utl/utensils', function() {
             assert.equal(false, _.sanitizeBooleanesque("0"));
         });
     });
-    
+
     describe('#deHTMLize() - ', function(){
         it(
-            "replaces < with &lt;", 
+            "replaces < with &lt;",
             () => assert.equal("&lt;", _.deHTMLize("<"))
         );
         it(
-            "replaces all < with &lt;", 
+            "replaces all < with &lt;",
             () => assert.equal(
                 "&lt;bla>hello&lt;/bla>",
                 _.deHTMLize("<bla>hello</bla>")
             )
         );
         it(
-            "leaves strings without < alone", 
+            "leaves strings without < alone",
             () => assert.equal(
                 "In Dutch, Huey, Louis and Dewy translate => Kwik, Kwek en Kwak",
                 _.deHTMLize(

--- a/src/script/ui/embedding/config.js
+++ b/src/script/ui/embedding/config.js
@@ -15,6 +15,7 @@ define([],function() {
         parentElementPrefix : "mscgen_js-parent_",
         clickable : false,
         clickURL : "https://sverweij.github.io/mscgen_js/",
+        loadFromSrcAttribute: false
     };
 
     function mergeConfig (pConfigBase, pConfigToMerge){

--- a/src/script/ui/embedding/error-rendering.js
+++ b/src/script/ui/embedding/error-rendering.js
@@ -1,0 +1,86 @@
+/* jshint nonstandard:true */
+/* jshint node: true */
+
+/* istanbul ignore else */
+if ( typeof define !== 'function') {
+    var define = require('amdefine')(module);
+}
+
+define([],function() {
+    "use strict";
+
+    /**
+     * Given a Number, emits a String with that number in, left padded so the
+     * string is pMaxWidth long. If the number doesn't fit within pMaxWidth
+     * characters, just returns a String with that number in it
+     *
+     * @param {number} pNumber
+     * @param {number} pMaxWidth
+     * @return {string} - the formatted number
+     */
+    function formatNumber(pNumber, pMaxWidth) {
+        var lRetval = pNumber.toString();
+        var lPosLeft = pMaxWidth - lRetval.length;
+        for (var i = 0; i < lPosLeft; i++) {
+            lRetval = " " + lRetval;
+        }
+        return lRetval;
+    }
+
+    function formatLine(pLine, pLineNo){
+        return formatNumber(pLineNo, 3) + " " + pLine;
+    }
+
+    function underlineCol(pLine, pCol){
+        return pLine.split("").reduce(function(pPrev, pChar, pIndex){
+            if (pIndex === pCol) {
+                return pPrev + "<span style='text-decoration:underline'>" + deHTMLize(pChar) + "</span>";
+            }
+            return pPrev + deHTMLize(pChar);
+        }, "");
+    }
+
+    /**
+     * returns a 'sanitized' version of the passed
+     * string. Sanitization is <em>very barebones</em> at the moment
+     * - it replaces < by &lt; so the browser won't start interpreting it
+     * as html. I'd rather use something standard for this, but haven't
+     * found it yet...
+     */
+    function deHTMLize(pString){
+        return pString.replace(/</g, "&lt;");
+    }
+
+    return {
+        formatNumber: formatNumber,
+        deHTMLize: deHTMLize,
+        renderError: function renderError(pSource, pErrorLocation, pMessage){
+            var lErrorIntro = !!pErrorLocation ?
+                "<pre><div style='color: red'># ERROR on line " + pErrorLocation.start.line + ", column " + pErrorLocation.start.column + " - " + pMessage + "</div>" :
+                "<pre><div style='color: red'># ERROR " + pMessage + "</div>";
+
+            return pSource.split('\n').reduce(function(pPrev, pLine, pIndex) {
+                if (!!pErrorLocation && pIndex === (pErrorLocation.start.line - 1)) {
+                    return pPrev + "<mark>" + formatLine(underlineCol(pLine, pErrorLocation.start.column - 1), pIndex + 1) + '\n' + "</mark>";
+                }
+                return pPrev + deHTMLize(formatLine(pLine, pIndex + 1)) + '\n';
+            }, lErrorIntro) + "</pre>";
+        }
+    };
+});
+/*
+ This file is part of mscgen_js.
+
+ mscgen_js is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ mscgen_js is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with mscgen_js.  If not, see <http://www.gnu.org/licenses/>.
+ */

--- a/src/script/ui/interpreter/uistate.js
+++ b/src/script/ui/interpreter/uistate.js
@@ -214,11 +214,16 @@ function setSample(pURL) {
     if ("none" === pURL || !pURL){
         clear();
     } else {
-        dq.ajax (pURL, function(pEvent){
-            setLanguage(txt.classifyExtension(pURL), false);
-            setSource(pEvent.target.response);
-            
-        });
+        dq.ajax (
+            pURL,
+            function onSuccess (pEvent){
+                setLanguage(txt.classifyExtension(pURL), false);
+                setSource(pEvent.target.response);
+            },
+            function onError (){
+                setSource("# could not find or open '" + pURL + "'");
+            }
+        );
     }
 }
 

--- a/src/script/ui/utl/domutl.js
+++ b/src/script/ui/utl/domutl.js
@@ -36,16 +36,24 @@ define([], function(){
                 pFunction(lNodes[i]);
             }
         },
-        ajax : function (pURL, pSuccessFunction) {
+        ajax : function (pURL, pSuccessFunction, pErrorFunction) {
             var lHttpRequest = new XMLHttpRequest();
             lHttpRequest.onreadystatechange = function (pEvent) {
-                if(pEvent.target.readyState === 4) {
-                    pSuccessFunction(pEvent);
+                if(pEvent.target.readyState === XMLHttpRequest.DONE) {
+                    if (200 === lHttpRequest.status) {
+                        pSuccessFunction(pEvent);    
+                    } else {
+                        pErrorFunction(pEvent);
+                    }
                 }
             };
             lHttpRequest.open('GET', pURL);
             lHttpRequest.responseType = "text";
-            lHttpRequest.send();
+            try {
+                lHttpRequest.send();
+            } catch (e) {
+                pErrorFunction();
+            }
         },
         // webkit (at least in Safari Version 6.0.5 (8536.30.1) which is
         // distibuted with MacOSX 10.8.4) omits the xmlns: and xlink:

--- a/src/script/ui/utl/domutl.js
+++ b/src/script/ui/utl/domutl.js
@@ -41,7 +41,7 @@ define([], function(){
             lHttpRequest.onreadystatechange = function (pEvent) {
                 if(pEvent.target.readyState === XMLHttpRequest.DONE) {
                     if (200 === lHttpRequest.status) {
-                        pSuccessFunction(pEvent);    
+                        pSuccessFunction(pEvent);
                     } else {
                         pErrorFunction(pEvent);
                     }

--- a/src/script/utl/utensils.js
+++ b/src/script/utl/utensils.js
@@ -60,12 +60,23 @@ define([], function() {
             return lMemoize;
         },
 
-        /*
+        /**
          * swaps the values of the attributes "from" and "two"
          * in the pPair object with each other
          */
         swapfromto : function (pPair){
             swap(pPair, "from", "to");
+        },
+
+        /**
+         * returns a 'sanitized' version of the passed
+         * string. Sanitization is <em>very barebones</em> at the moment
+         * - it replaces < by &lt; so the browser won't start interpreting it
+         * as html. I'd rather use something standard for this, but haven't
+         * found it yet...
+         */
+        deHTMLize : function(pString){
+            return pString.replace(/</g, "&lt;");
         },
 
         /**

--- a/src/script/utl/utensils.js
+++ b/src/script/utl/utensils.js
@@ -69,17 +69,6 @@ define([], function() {
         },
 
         /**
-         * returns a 'sanitized' version of the passed
-         * string. Sanitization is <em>very barebones</em> at the moment
-         * - it replaces < by &lt; so the browser won't start interpreting it
-         * as html. I'd rather use something standard for this, but haven't
-         * found it yet...
-         */
-        deHTMLize : function(pString){
-            return pString.replace(/</g, "&lt;");
-        },
-
-        /**
          * returns true if pString equals "1", "true", "y", "yes" or "on"
          * ... false in all other cases
          * @param {string} pString
@@ -87,25 +76,8 @@ define([], function() {
          */
         sanitizeBooleanesque: function(pString){
             return (["1", "true", "y", "yes", "on"].indexOf(pString) > -1);
-        },
-
-        /**
-         * Given a Number, emits a String with that number in, left padded so the
-         * string is pMaxWidth long. If the number doesn't fit within pMaxWidth
-         * characters, just returns a String with that number in it
-         *
-         * @param {number} pNumber
-         * @param {number} pMaxWidth
-         * @return {string} - the formatted number
-         */
-        formatNumber : function(pNumber, pMaxWidth) {
-            var lRetval = pNumber.toString();
-            var lPosLeft = pMaxWidth - lRetval.length;
-            for (var i = 0; i < lPosLeft; i++) {
-                lRetval = " " + lRetval;
-            }
-            return lRetval;
         }
+
     };
 });
 /*


### PR DESCRIPTION
- When the `mscgen_js_config` contains the attribute `loadFromSrcAttribute`, mscgen-inpage.js will try to render the chart specified in the `data-src` attribute of the mscgen_js elements.
- In the default config `loadFromSrcAttribute` is _false_. So, if you want to use this feature, you'll have to explicitly enable it - at least for now.     
- Fixes #211, which was a suggestion from @jbcpollak in issue #206 

## Sample
During the life of this PR also deployed on a feature branch:
[https://sverweij.github.io/mscgen_js/branches/feature/read-external-scripts/samples/embedexternal.html](https://sverweij.github.io/mscgen_js/branches/feature/read-external-scripts/samples/embedexternal.html)

The new mscgen-inpage.js script resides here:
[https://sverweij.github.io/mscgen_js/branches/feature/read-external-scripts/mscgen-inpage.js](https://sverweij.github.io/mscgen_js/branches/feature/read-external-scripts/mscgen-inpage.js)

### HTML
```html
<!DOCTYPE html>
<html lang="en">
    <head>
        <meta http-equiv="Content-Type" content="text/html;charset=utf-8" >
        <script>
          var mscgen_js_config = {
            clickable: true,
            loadFromSrcAttribute: true
          }
        </script>
    <script src='http://localhost:8666/mscgen-inpage.js' defer></script>
    </head>
    <body>
        <h2>Read from an external file</h2>
        <div data-src="https://sverweij.github.io/mscgen_js/samples/test21_unicode_colored.mscin"></div>

        <h2>Read from a non-existing external file</h2>
        <p>Should display an error message</p>
        <mscgen data-src="thisfiledoesnotexist.mscin"></mscgen>

        <h2>Embedded in the page and a src attribute</h2>
        <p>
            The stuff in the src attribute wins. In
            this case means we see a unicode exchange, and not labels a,b and c introducing each other
        </p>
        <pre class="mscgen_js" data-src="https://sverweij.github.io/mscgen_js/samples/test21a_unicode_serious.msgenny" data-language="msgenny">
a, b, c;

b => * : hello world;
a >> b : hello b,
c >> b : hello b;
        </pre>
    </body>
</html>
```
### Rendered output
![result](https://cloud.githubusercontent.com/assets/4822597/11049698/9dc8c732-8740-11e5-8877-eb7bdf3ac7ab.png)