### PR TITLE
moves the samples file names embedded in the html to an external config

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -137,53 +137,7 @@ saves the current chart to local storage"></button>
 loads the most recently saved chart from local storage"></button>
                 </span>
                 <span>
-                    <select title="list of samples" id="__samples">
-                        <option value="none" selected>select an example...</option>
-                        <optgroup label="introductory">
-                            <option value="samples/intro01_simple_starter.msgenny">simple (msgenny)</option>
-                            <option value="samples/intro02_starter.mscgen">start (mscgen)</option>
-                            <option value="samples/intro03_cheat_sheet.msgenny">cheating (msgenny)</option>
-                            <option class="debug" value="samples/intro04_elaborate_cheat_sheet.msgenny">elaborate cheat sheet</option>
-                        </optgroup>
-                        <optgroup label="samples">
-                            <option value="samples/sample01_bob_alice.mscin">PKI</option>
-                            <option value="samples/3rdparty/fbauth.xu">Facebook auth</option>
-                            <option value="samples/sample03_sip_(from_wikipedia).mscin">SIP</option>
-                            <option value="samples/sample04_intermediate_proxy_(from_wikipedia).mscin">SIP proxy</option>
-                            <option value="samples/sample05_smtp.mscin">SMTP</option>
-                            <option value="samples/3rdparty/acme-processing-01-challenge.msgenny">ACME Challenge</option>
-                            <option value="samples/3rdparty/acme-processing-02-authorization.msgenny">ACME Auth</option>
-                            <option value="samples/3rdparty/acme-processing-03-certificate.msgenny">ACME Cert</option>
-                            <option value="samples/3rdparty/acme-processing-04-revocation.msgenny">ACME Revoke</option>
-                            <option value="samples/sample10_how_mscgen_js_works.mscin">mscgen_js</option>
-                        </optgroup>
-                        <optgroup label="tests">
-                            <option class="debug" style="display: none" value="samples/test11_autodeclaration.msgenny">auto entities</option>
-                            <option value="samples/test01_all_possible_arcs.mscin">all arcs in mscgen</option>
-                            <option value="samples/test01_all_possible_arcs.xu">all arcs in xù</option>
-                            <option value="samples/test02_some_coloring.mscin">colors</option>
-                            <option class="debug" style="display: none" value="samples/test50_expansions.xu">inline expressions</option>
-                            <option class="debug" style="display: none" value="samples/rainbow.mscin">rainbow</option>
-                            <option class="debug" style="display: none" value="samples/test16_multiline_in_detail.mscin">multiline zoomed</option>
-                            <option class="debug" style="display: none" value="samples/test17_multiline_in_boxes.msgenny">multilines in boxes</option>
-                            <option class="debug" style="display: none" value="samples/test18_multiline_broadcasts.msgenny">multiline broadcasts</option>
-                            <option class="debug" style="display: none" value="samples/test23_all_signal_variants.msgenny">signals!</option>
-                            <option class="debug" style="display: none" value="samples/test19_multiline_lipsum.mscin">multiline autowrap</option>
-                            <option value="samples/3rdparty/test20_quoteless_attributes.mscin">quoteless attributes</option>
-                            <option value="samples/test21_unicode_colored.mscin">unicode 信息序圖</option>
-                            <option value="samples/test21a_unicode_serious.msgenny">serious unicode</option>
-                            <option value="samples/test21b_emoji.msgenny">👳=>🏦:💰@🏭;</option>
-
-                            <option value="samples/readme.mscin">readme sample</option>
-                            <option value="samples/test24_pile_of_poo_test.mscin">pile of poo test</option>
-                        </optgroup>
-                        <optgroup label="weird">
-                            <option value="samples/test09_arcskip_over_there.mscin">skipping arcs</option>
-                            <option value="samples/test42_strangeuse.mscin">scheduling</option>
-                            <option value="samples/test43_flag.mscin">flag</option>
-                            <option value="samples/test44_anotherabuse.mscgen">pushing it</option>
-                        </optgroup>
-                    </select>
+                    <select title="list of samples" id="__samples" style="display:none"></select>
                 </span>
             </div>
             <textarea id="__msc_input" class="code mscgen" spellcheck="false" title="your input text:"></textarea>

--- a/src/jsdependencies.mk
+++ b/src/jsdependencies.mk
@@ -101,6 +101,9 @@ src/script/lib/codemirror/mode/javascript/javascript.js: \
 src/script/lib/codemirror/mode/mscgen/mscgen.js: \
 	src/script/lib/codemirror/lib/codemirror.js
 
+src/script/lib/mscgenjs-core/render/graphics/csstemplates.js: \
+	src/script/lib/mscgenjs-core/lib/lodash/lodash.custom.js
+
 src/script/lib/mscgenjs-core/render/graphics/entities.js: \
 	src/script/lib/mscgenjs-core/render/graphics/constants.js \
 	src/script/lib/mscgenjs-core/render/graphics/renderlabels.js
@@ -133,8 +136,8 @@ src/script/lib/mscgenjs-core/render/graphics/renderlabels.js: \
 	src/script/lib/mscgenjs-core/render/text/textutensils.js
 
 src/script/lib/mscgenjs-core/render/graphics/renderskeleton.js: \
-	src/script/lib/mscgenjs-core/render/graphics/csstemplates.js \
 	src/script/lib/mscgenjs-core/render/graphics/constants.js \
+	src/script/lib/mscgenjs-core/render/graphics/csstemplates.js \
 	src/script/lib/mscgenjs-core/render/graphics/svgelementfactory.js
 
 src/script/lib/mscgenjs-core/render/graphics/svgelementfactory.js: \
@@ -234,6 +237,10 @@ src/script/lib/codemirror/mode/javascript/javascript.js: \
 
 src/script/lib/codemirror/mode/mscgen/mscgen.js: \
 	src/script/lib/codemirror/lib/codemirror.js
+
+src/script/test/interpreter/t_sampleListReader.js: \
+	src/script/interpreter/sampleListReader.js \
+	src/script/test/interpreter/sampleListReaderFixture.json
 
 src/script/test/utl/t_exporter.js: \
 	src/script/utl/exporter.js

--- a/src/samples/interpreter-samples.json
+++ b/src/samples/interpreter-samples.json
@@ -33,6 +33,10 @@
         "value": "samples/3rdparty/fbauth.xu"
       },
       {
+          "label": "reCaptcha",
+          "value": "samples/recaptcha-integration.xu"
+      },
+      {
         "label": "SIP",
         "value": "samples/sample03_sip_(from_wikipedia).mscin"
       },

--- a/src/samples/interpreter-samples.json
+++ b/src/samples/interpreter-samples.json
@@ -1,0 +1,171 @@
+[
+  {
+    "label": "introductory",
+    "values": [
+      {
+        "label": "simple (msgenny)",
+        "value": "samples/intro01_simple_starter.msgenny"
+      },
+      {
+        "label": "start (mscgen)",
+        "value": "samples/intro02_starter.mscgen"
+      },
+      {
+        "label": "cheating (msgenny)",
+        "value": "samples/intro03_cheat_sheet.msgenny"
+      },
+      {
+        "label": "elaborate cheatsheet",
+        "value": "samples/intro04_elaborate_cheat_sheet.msgenny",
+        "debug": true
+      }
+    ]
+  },
+  {
+    "label": "samples",
+    "values": [
+      {
+        "label": "PKI",
+        "value": "samples/sample01_bob_alice.mscin"
+      },
+      {
+        "label": "Facebook auth",
+        "value": "samples/3rdparty/fbauth.xu"
+      },
+      {
+        "label": "SIP",
+        "value": "samples/sample03_sip_(from_wikipedia).mscin"
+      },
+      {
+        "label": "SIP proxy",
+        "value": "samples/sample04_intermediate_proxy_(from_wikipedia).mscin"
+      },
+      {
+        "label": "SMTP",
+        "value": "samples/sample05_smtp.mscin"
+      },
+      {
+        "label": "ACME Challenge",
+        "value": "samples/3rdparty/acme-processing-01-challenge.msgenny"
+      },
+      {
+        "label": "ACME Auth",
+        "value": "samples/3rdparty/acme-processing-02-authorization.msgenny"
+      },
+      {
+        "label": "ACME Cert",
+        "value": "samples/3rdparty/acme-processing-03-certificate.msgenny"
+      },
+      {
+        "label": "ACME Revoke",
+        "value": "samples/3rdparty/acme-processing-04-revocation.msgenny"
+      },
+      {
+        "label": "mscgen_js",
+        "value": "samples/sample10_how_mscgen_js_works.mscin"
+      }
+    ]
+  },
+  {
+    "label": "tests",
+    "values": [
+      {
+        "label": "auto entities",
+        "value": "samples/test11_autodeclaration.msgenny",
+        "debug": true
+      },
+      {
+        "label": "all arcs in mscgen",
+        "value": "samples/test01_all_possible_arcs.mscin"
+      },
+      {
+        "label": "all arcs in xù",
+        "value": "samples/test01_all_possible_arcs.xu"
+      },
+      {
+        "label": "colors",
+        "value": "samples/test02_some_coloring.mscin"
+      },
+      {
+        "label": "inline expressions",
+        "value": "samples/test50_expansions.xu",
+        "debug": true
+      },
+      {
+        "label": "rainbow",
+        "value": "samples/rainbow.mscin",
+        "debug": true
+      },
+      {
+        "label": "multiline zoomed",
+        "value": "samples/test16_multiline_in_detail.mscin",
+        "debug": true
+      },
+      {
+        "label": "multilines in boxes",
+        "value": "samples/test17_multiline_in_boxes.msgenny",
+        "debug": true
+      },
+      {
+        "label": "multiline broadcasts",
+        "value": "samples/test18_multiline_broadcasts.msgenny",
+        "debug": true
+      },
+      {
+        "label": "signals!",
+        "value": "samples/test23_all_signal_variants.msgenny",
+        "debug": true
+      },
+      {
+        "label": "multiline autowrap",
+        "value": "samples/test19_multiline_lipsum.mscin",
+        "debug": true
+      },
+      {
+        "label": "quoteless attributes",
+        "value": "samples/3rdparty/test20_quoteless_attributes.mscin"
+      },
+      {
+        "label": "unicode 信息序圖",
+        "value": "samples/test21_unicode_colored.mscin"
+      },
+      {
+        "label": "serious unicode",
+        "value": "samples/test21a_unicode_serious.msgenny"
+      },
+      {
+        "label": "👳=>🏦:💰@🏭;",
+        "value": "samples/test21b_emoji.msgenny"
+      },
+      {
+        "label": "readme sample",
+        "value": "samples/readme.mscin"
+      },
+      {
+        "label": "pile of poo test",
+        "value": "samples/test24_pile_of_poo_test.mscin"
+      }
+    ]
+  },
+  {
+    "label": "weird",
+    "values": [
+      {
+        "label": "skipping arcs",
+        "value": "samples/test09_arcskip_over_there.mscin"
+      },
+      {
+        "label": "scheduling",
+        "value": "samples/test42_strangeuse.mscin"
+      },
+      {
+        "label": "flag",
+        "value": "samples/test43_flag.mscin"
+      },
+      {
+        "label": "pushing it",
+        "value": "samples/test44_anotherabuse.mscgen"
+      }
+    ]
+  }
+]

--- a/src/samples/recaptcha-integration.xu
+++ b/src/samples/recaptcha-integration.xu
@@ -1,0 +1,37 @@
+/*
+ * a possible re-Captcha integration, assuming the client has
+ * the re-Captcha widget embedded in the site
+ *
+ * Please refer to https://developers.google.com/recaptcha/intro
+ * if you're serious about implementing re-Captcha
+ */
+
+xu {
+  wordwraparcs=true;
+
+  customer [linecolor=red,  arclinecolor=red,  textbgcolor="#FFCCCC"],
+  client   [linecolor=blue, arclinecolor=blue, textbgcolor="#CCCCFF"],
+  server   [linecolor=blue, arclinecolor=blue, textbgcolor="#CCCCFF"],
+  google   [label="Google reCaptcha service", linecolor=fuchsia, arclinecolor=fuchsia, textbgcolor="#FFCCFF"];
+
+  customer => client [label="log in with credentials, reCaptcha"];
+  client   => google [label="getResponse(reCaptcha)"];
+  google   >> client [label="reCaptcha response"];
+  client   => server [label="POST credentials, reCaptcha response"];
+  server   => google [label="POST reCaptcha response, secret"];
+  customer alt google [label="reCaptcha valid", linecolor="grey", textbgcolor="white"] {
+    google   >> server [label="OK"];
+    server rbox server [label="check hostname, error codes"];
+    server rbox server [label="do regular login processing"];
+
+    --- [label="reCaptcha not valid", linecolor=grey, textbgcolor=white];
+    google >> server   [label="NOK"];
+    server >> client   [label="HTTP 40x 'reCaptcha'"];
+    client >> customer [label="sorry dude - captcha didn't check out"];
+
+    --- [label="other error and/ or time-out", linecolor=grey, textbgcolor=white];
+    ..., google -x server;
+    server >> client   [label="Error (HTTP 500?)"];
+    client >> customer [label="sorry dude"];
+  };
+}

--- a/src/script/interpreter/sampleListReader.js
+++ b/src/script/interpreter/sampleListReader.js
@@ -1,0 +1,48 @@
+/* jshint browser:true */
+/* jshint node:true */
+
+/* istanbul ignore else */
+if ( typeof define !== 'function') {
+    var define = require('amdefine')(module);
+}
+
+define([], function(){
+    "use strict";
+    var gDebug = false;
+
+    function toOptions(pPrev, pSample) {
+        return pPrev + '<option value="' + pSample.value + '">' + pSample.label + "</option>";
+    }
+
+    function toOptionGroups(pPrev, pSampleGroup){
+        return pPrev + '<optgroup label="' + pSampleGroup.label + '">' +
+            pSampleGroup
+                .values
+                .filter(function(value) {return (!value.debug||gDebug); })
+                .reduce(toOptions, "") +
+        '</optgroup>';
+    }
+
+    return {
+        toOptionList: function (pSampleGroups, pDebug) {
+            gDebug = !!pDebug;
+            return pSampleGroups.reduce(toOptionGroups, "");
+        }
+    };
+});
+/*
+ This file is part of mscgen_js.
+
+ mscgen_js is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ mscgen_js is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with mscgen_js.  If not, see <http://www.gnu.org/licenses/>.
+ */

--- a/src/script/interpreter/uistate.js
+++ b/src/script/interpreter/uistate.js
@@ -87,7 +87,10 @@ define(["../lib/mscgenjs-core/parse/xuparser", "../lib/mscgenjs-core/parse/msgen
                 try {
                     window.__samples.innerHTML =
                         '<option value="none" selected="">select an example...</option>' +
-                        sampleListReader.toOptionList(pResult.target.response, gDebug);
+                        sampleListReader.toOptionList(
+                            JSON.parse(pResult.target.response),
+                            gDebug
+                        );
                     dq.SS(window.__samples).show();
                 } catch (e) {
                     // quietly ignore
@@ -95,8 +98,7 @@ define(["../lib/mscgenjs-core/parse/xuparser", "../lib/mscgenjs-core/parse/msgen
             },
             function(){
                 //quietly ignore
-            },
-            "json"
+            }
         );
         if (window.__loading) {
             window.__loading.outerHTML = "";

--- a/src/script/interpreter/uistate.js
+++ b/src/script/interpreter/uistate.js
@@ -43,9 +43,10 @@ define(["../lib/mscgenjs-core/parse/xuparser", "../lib/mscgenjs-core/parse/msgen
         "../lib/mscgenjs-core/render/text/ast2msgenny", "../lib/mscgenjs-core/render/text/ast2xu",
         "../utl/gaga", "../utl/maps",
         "../utl/domutl",
-        "../utl/exporter"
+        "../utl/exporter",
+        "./sampleListReader"
         ],
-        function(mscparser, msgennyparser, msc_render, tomsgenny, tomscgen, gaga, txt, dq, xport) {
+        function(mscparser, msgennyparser, msc_render, tomsgenny, tomscgen, gaga, txt, dq, xport, sampleListReader) {
     "use strict";
 
     var gAutoRender = true;
@@ -80,6 +81,23 @@ define(["../lib/mscgenjs-core/parse/xuparser", "../lib/mscgenjs-core/parse/msgen
         gCodeMirror = pCodeMirror;
         showAutorenderState (gAutoRender);
         setLanguage(getLanguage(), false);
+        dq.ajax(
+            "samples/interpreter-samples.json",
+            function(pResult){
+                try {
+                    window.__samples.innerHTML =
+                        '<option value="none" selected="">select an example...</option>' +
+                        sampleListReader.toOptionList(pResult.target.response, gDebug);
+                    dq.SS(window.__samples).show();
+                } catch (e) {
+                    // quietly ignore
+                }
+            },
+            function(){
+                //quietly ignore
+            },
+            "json"
+        );
         if (window.__loading) {
             window.__loading.outerHTML = "";
         }

--- a/src/script/test/interpreter/sampleListReaderFixture.json
+++ b/src/script/test/interpreter/sampleListReaderFixture.json
@@ -1,0 +1,34 @@
+[
+  {
+    "label": "first option group",
+    "values": [
+      {
+        "label": "debug not specified",
+        "value": "samples/debug-not-specified.mscgen"
+      },
+      {
+        "label": "debug false",
+        "value": "samples/debug-false-sample.mscgen",
+        "debug": false
+      },
+      {
+        "label": "debug true",
+        "value": "samples/debug-true-sample.mscgen",
+        "debug": true
+      }
+    ]
+  },
+  {
+      "label": "second option group",
+      "values": [
+          {
+              "label": "mesjogge",
+              "value": "getikt"
+          },
+          {
+              "label": "knetter",
+              "value": "leip"
+          }
+      ]
+  }
+]

--- a/src/script/test/interpreter/t_sampleListReader.js
+++ b/src/script/test/interpreter/t_sampleListReader.js
@@ -1,0 +1,19 @@
+/* jshint nonstandard: true */
+var sampleListReader = require("../../interpreter/sampleListReader");
+var fixture = require("./sampleListReaderFixture.json");
+var expect = require("chai").expect;
+
+describe('sampleListReader', function() {
+    var OPTIONS_NO_DEBUG_FIXTURE='<optgroup label="first option group"><option value="samples/debug-not-specified.mscgen">debug not specified</option><option value="samples/debug-false-sample.mscgen">debug false</option></optgroup><optgroup label="second option group"><option value="getikt">mesjogge</option><option value="leip">knetter</option></optgroup>';
+    var OPTIONS_DEBUG_FIXTURE='<optgroup label="first option group"><option value="samples/debug-not-specified.mscgen">debug not specified</option><option value="samples/debug-false-sample.mscgen">debug false</option><option value="samples/debug-true-sample.mscgen">debug true</option></optgroup><optgroup label="second option group"><option value="getikt">mesjogge</option><option value="leip">knetter</option></optgroup>';
+
+    it('should return no debug options when debug not specified', function() {
+        expect(sampleListReader.toOptionList(fixture)).to.equal(OPTIONS_NO_DEBUG_FIXTURE);
+    });
+    it('should return no debug options when debug false', function() {
+        expect(sampleListReader.toOptionList(fixture, false)).to.equal(OPTIONS_NO_DEBUG_FIXTURE);
+    });
+    it('should also return debug options when debug true', function() {
+        expect(sampleListReader.toOptionList(fixture, true)).to.equal(OPTIONS_DEBUG_FIXTURE);
+    });
+});

--- a/src/script/utl/domutl.js
+++ b/src/script/utl/domutl.js
@@ -48,7 +48,7 @@ define([], function(){
                 }
             };
             lHttpRequest.open('GET', pURL);
-            lHttpRequest.responseType = !!pResponseType ? pResponseType : "text";
+            lHttpRequest.responseType = pResponseType||"text";
             try {
                 lHttpRequest.send();
             } catch (e) {

--- a/src/script/utl/domutl.js
+++ b/src/script/utl/domutl.js
@@ -36,7 +36,7 @@ define([], function(){
                 pFunction(lNodes[i]);
             }
         },
-        ajax : function (pURL, pSuccessFunction, pErrorFunction, pResponseType) {
+        ajax : function (pURL, pSuccessFunction, pErrorFunction) {
             var lHttpRequest = new XMLHttpRequest();
             lHttpRequest.onreadystatechange = function (pEvent) {
                 if(pEvent.target.readyState === XMLHttpRequest.DONE) {
@@ -48,7 +48,7 @@ define([], function(){
                 }
             };
             lHttpRequest.open('GET', pURL);
-            lHttpRequest.responseType = pResponseType||"text";
+            lHttpRequest.responseType = "text";
             try {
                 lHttpRequest.send();
             } catch (e) {

--- a/src/script/utl/domutl.js
+++ b/src/script/utl/domutl.js
@@ -36,7 +36,7 @@ define([], function(){
                 pFunction(lNodes[i]);
             }
         },
-        ajax : function (pURL, pSuccessFunction, pErrorFunction) {
+        ajax : function (pURL, pSuccessFunction, pErrorFunction, pResponseType) {
             var lHttpRequest = new XMLHttpRequest();
             lHttpRequest.onreadystatechange = function (pEvent) {
                 if(pEvent.target.readyState === XMLHttpRequest.DONE) {
@@ -48,7 +48,7 @@ define([], function(){
                 }
             };
             lHttpRequest.open('GET', pURL);
-            lHttpRequest.responseType = "text";
+            lHttpRequest.responseType = !!pResponseType ? pResponseType : "text";
             try {
                 lHttpRequest.send();
             } catch (e) {


### PR DESCRIPTION
... and reads them
- also makes sure that when it's not possible to use ajax (e.g. when using the file:// protocol) the interpreter doesn't show the sample list
- as dynamically showing individual <options> doesn't depend on individual browser's interpretation of what to do with styling options, options to be shown in debug mode only now are respected on _all browsers_