### PR TITLE
WIP: auto save settings or so

### DIFF
--- a/src/embed.html
+++ b/src/embed.html
@@ -134,6 +134,9 @@
                 <a href="#mirror-entities">Mirror entities on the bottom</a>
             </li>
             <li>
+                <a href="#named-styles">Use a named style</a>
+            </li>
+            <li>
                 <a href="#supported-browsers">Supported browsers</a>
             </li>
             <li>
@@ -343,7 +346,7 @@ msc {
                     <code>script</code> tag:)
                     <pre class="code">&lt;script
     <mark>src="./samples/test21a_unicode_serious.msgenny"</mark>
-    type="text/x-mscgen">&lt;/script></pre>
+    type="text/x-msgenny">&lt;/script></pre>
                 </p>
             </li>
 
@@ -395,6 +398,94 @@ msc {
             b >> a  [label="Really?"];
         }
         </script>
+        <h2 id="named-styles">Use a named style</h2>
+        <p>
+            If you want to represent the chart a little different, from version
+            1.4.2 mscgenjs supports some 'named styles'. They'll add the most
+            value when you use plain MsGenny or MscGen that do not contain
+            any colors - as colors defined in scripts have precedence.
+        </p>
+        <pre class="code">&lt;script <mark>data-named-style='lazy'</mark>
+        src="samples/sample11_basic_named_style_demo.msgenny"
+        type="text/x-msgenny">
+&lt;/script></pre>
+        <p>
+            This is how the same simple chart looks <em>without</em> and
+            <em>with</em> a style (<code>lazy</code>):
+        </p>
+        <p>
+            <script src='./samples/sample11_basic_named_style_demo.msgenny' type="text/x-msgenny"></script>
+            <script src='./samples/sample11_basic_named_style_demo.msgenny' data-named-style='lazy' type="text/x-msgenny"></script>
+        </p>
+        <p>
+            The complete list of named styles:
+            <ul>
+                <li>
+                    <strong>lazy</strong>
+                    <ul>
+                        <li>
+                            uses a bold font for entity names (instead of
+                            underlining them)
+                        </li>
+                        <li>
+                            prints return value text in italics
+                        </li>
+                        <li>
+                            inline expression boxes get a dark grey outline
+                            (instead of the default black)
+                        </li>
+                    </ul>
+                </li>
+                <li>
+                    <strong>classic</strong>
+                    <ul>
+                        <li>
+                            Mimics the vanilla MscGen output
+                        </li>
+                        <li>
+                            makes all lines 1 pixel wide
+                        </li>
+                        <li>
+                            entities are just text - not boxes (except when the
+                            entity has a <code>textbgcolor</code>)
+                        </li>
+                    </ul>
+                </li>
+                <li>
+                    <strong>cygne</strong>
+                    <ul>
+                        <li>
+                            a light blue/ orange scheme
+                        </li>
+                        <li>
+                            Primarily meant to quickly color a chart written
+                            in either MsGenny or MscGen/ Xù with sparse use
+                            of colors.
+                        </li>
+                        <li>
+                            If your chart already contains colors
+                            this named style will probably be unhelpful.
+                        </li>
+                    </ul>
+                </li>
+                <li>
+                    <strong>pegasse</strong>
+                    <ul>
+                        <li>
+                            A dark blue/ red scheme.
+                        </li>
+                        <li>
+                            Primarily meant to quickly color a chart written
+                            in either MsGenny or MscGen/ Xù with sparse use
+                            of colors.
+                        </li>
+                        <li>
+                            Also not very helpful for already colored charts.
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+        </p>
         <h2 id="supported-browsers">Supported browsers: most</h2>
         <p>
             We have verified in page script to work in all

--- a/src/samples/sample11_basic_named_style_demo.msgenny
+++ b/src/samples/sample11_basic_named_style_demo.msgenny
@@ -1,0 +1,10 @@
+hscale=0.8,wordwraparcs=on;
+
+Alice =>> Bob : "We're inside an msgenny script";
+Bob alt Alice : "Sunny weather" {
+    Bob >> Alice : "That feels nice";
+    --- : "Cloudy";
+    Bob >> Alice : "That feels ... different",
+    notes abox notes: ... and so can boxes;
+},
+notes note notes : "Notes could get an independent background & font color";

--- a/src/script/interpreter/nav-actions.js
+++ b/src/script/interpreter/nav-actions.js
@@ -38,7 +38,11 @@ function(uistate, animctrl, xport, dq, gactions, gaga) {
                 xport.toHTMLSnippet(
                     uistate.getSource(),
                     uistate.getLanguage(),
-                    uistate.getLinkToInterpeter()
+                    {
+                        withLinkToEditor: uistate.getLinkToInterpeter(),
+                        mirrorEntities: uistate.getMirrorEntities(),
+                        namedStyle: uistate.getStyle()
+                    }
                 );
             gactions.togglePanel(
                 window.__embed_panel,
@@ -53,7 +57,15 @@ function(uistate, animctrl, xport, dq, gactions, gaga) {
         linkToInterpreterOnClick: function() {
             uistate.setLinkToInterpeter(!(uistate.getLinkToInterpeter()));
             window.__embedsnippet.textContent =
-            xport.toHTMLSnippet(uistate.getSource(), uistate.getLanguage(), uistate.getLinkToInterpeter());
+                xport.toHTMLSnippet(
+                    uistate.getSource(),
+                    uistate.getLanguage(),
+                    {
+                        withLinkToEditor: uistate.getLinkToInterpeter(),
+                        mirrorEntities: uistate.getMirrorEntities(),
+                        namedStyle: uistate.getStyle()
+                    }
+                );
             uistate.showAutorenderState(uistate.getAutoRender());
             gaga.g('send', 'event', 'toggle_autorender', 'checkbox');
         },

--- a/src/script/interpreter/output-actions.js
+++ b/src/script/interpreter/output-actions.js
@@ -55,7 +55,17 @@ function(uistate, animctrl, xport, rxport, dq, gactions, gaga) {
             gaga.g('send', 'event', 'show_jpeg_base64', 'button');
         },
         htmlOnClick: function() {
-            window.open(xport.toHTMLSnippetURI(uistate.getSource(), uistate.getLanguage()));
+            window.open(
+                xport.toHTMLSnippetURI(
+                    uistate.getSource(),
+                    uistate.getLanguage(),
+                    {
+                        withLinkToEditor: uistate.getLinkToInterpeter(),
+                        mirrorEntities: uistate.getMirrorEntities(),
+                        namedStyle: uistate.getStyle()
+                    }
+                )
+            );
             gaga.g('send', 'event', 'show_html', 'button');
         },
         dotOnClick: function() {

--- a/src/script/interpreter/output-actions.js
+++ b/src/script/interpreter/output-actions.js
@@ -12,11 +12,11 @@ function(uistate, animctrl, xport, rxport, dq, gactions, gaga) {
 
     var IMAGE_EXPORT_WINDOW_NAME = "mscgenjsimages";
     function rasterExport(pType){
-/*
- * first open a window directly as opening windows from the img.load
- * (as the anonymous function will do) is blocked by many browsers
- * (safari: hard, firefox: asks the user for for permission)
- */
+        /*
+         * first open a window directly as opening windows from the img.load
+         * (as the anonymous function will do) is blocked by many browsers
+         * (safari: hard, firefox: asks the user for for permission)
+         */
         window.open("about:blank", IMAGE_EXPORT_WINDOW_NAME);
         rxport.toRasterURI(
             document,

--- a/src/script/interpreter/param-actions.js
+++ b/src/script/interpreter/param-actions.js
@@ -37,6 +37,11 @@ define(["./uistate",
                     gaga.g('send', 'event', 'params.mirrorentities', lParams.mirrorentities);
                 }
 
+                if (lParams.hasOwnProperty("style")) {
+                    uistate.setStyle(lParams.style);
+                    gaga.g('send', 'event', 'params.style', lParams.style);
+                }
+
                 if (lParams.lang){
                     uistate.setLanguage(lParams.lang);
                     gaga.g('send', 'event', 'params.lang', lParams.lang);

--- a/src/script/interpreter/uistate.js
+++ b/src/script/interpreter/uistate.js
@@ -420,7 +420,26 @@ function(mscparser, msgennyparser, msc_render, tomsgenny, tomscgen, gaga, txt, d
             return gMirrorEntitiesOnBottom;
         },
         setStyle: function(pStyle) {
-            gNamedStyle = pStyle;
+            window.__option_style_none.checked       = false;
+            window.__option_style_inverted.checked   = false;
+            window.__option_style_grayscaled.checked = false;
+            window.__option_style_lazy.checked       = false;
+            window.__option_style_cygne.checked      = false;
+            window.__option_style_pegasse.checked    = false;
+            window.__option_style_classic.checked    = false;
+
+            var lOptionToCheck = document.getElementById('__option_style_' + pStyle);
+            if (Boolean(lOptionToCheck)){
+                lOptionToCheck.checked = true;
+                gNamedStyle = pStyle;
+            } else {
+                window.__option_style_none.checked = true;
+                gNamedStyle = "none";
+            }
+
+        },
+        getStyle: function() {
+            return gNamedStyle;
         },
 
         showAutorenderState: showAutorenderState

--- a/src/script/lib/mscgenjs-core/render/graphics/renderskeleton.js
+++ b/src/script/lib/mscgenjs-core/render/graphics/renderskeleton.js
@@ -70,7 +70,7 @@ define(["./svgelementfactory", "./constants", "./csstemplates"], function(fact, 
         lBody.appendChild(fact.createGroup(pElementId + "__sequencelayer"));
         lBody.appendChild(fact.createGroup(pElementId + "__notelayer"));
         lBody.appendChild(fact.createGroup(pElementId + "__watermark"));
-        lBody.appendChild(fact.createGroup(pElementId + "__onionskin", "onionskin"));
+        // lBody.appendChild(fact.createGroup(pElementId + "__onionskin", "onionskin"));
         return lBody;
     }
 

--- a/src/script/test/utl/exporter.spec.js
+++ b/src/script/test/utl/exporter.spec.js
@@ -40,6 +40,7 @@ var gAST = {
 };
 var gSVG = '<svg>just a dummy thing</svg>';
 var gMsc = 'msc{a[label="💩"],b[label="序"],c [label="💩"]; a => b[label="things"], c => b;}';
+var gMsGenny = 'a : 💩, b : 序, c : 💩; a => b : things, c => b;';
 
 describe('ui/utl/exporter', function(){
     describe('#toVectorURI', function(){
@@ -51,15 +52,41 @@ describe('ui/utl/exporter', function(){
     });
     describe('#toHTMLSnippetURI', function(){
         it('should render an URI encoded html file with the passed chart embedded', function(){
-            assert.equal(xport.toHTMLSnippetURI(gMsc, 'mscgen'),
-            "data:text/plain;charset=utf-8,%3C!DOCTYPE%20html%3E%0A%3Chtml%3E%0A%20%20%3Chead%3E%0A%20%20%20%20%3Cmeta%20content%3D'text%2Fhtml%3Bcharset%3Dutf-8'%20http-equiv%3D'Content-Type'%3E%0A%20%20%20%20%3Cscript%20src%3D'https%3A%2F%2Fsverweij.github.io%2Fmscgen_js%2Fmscgen-inpage.js'%20defer%3E%0A%20%20%20%20%3C%2Fscript%3E%0A%20%20%3C%2Fhead%3E%0A%20%20%3Cbody%3E%0A%20%20%20%20%3Cpre%20class%3D'code%20mscgen%20mscgen_js'%20data-language%3D'mscgen'%3E%0Amsc%7Ba%5Blabel%3D%22%F0%9F%92%A9%22%5D%2Cb%5Blabel%3D%22%E5%BA%8F%22%5D%2Cc%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%3B%20a%20%3D%3E%20b%5Blabel%3D%22things%22%5D%2C%20c%20%3D%3E%20b%3B%7D%0A%20%20%20%20%3C%2Fpre%3E%0A%20%20%3C%2Fbody%3E%0A%3C%2Fhtml%3E");
+            assert.equal(xport.toHTMLSnippetURI(gMsc, 'mscgen', {}),
+            "data:text/plain;charset=utf-8,%3C!DOCTYPE%20html%3E%0A%3Chtml%3E%0A%20%20%3Chead%3E%0A%20%20%20%20%3Cmeta%20content%3D'text%2Fhtml%3Bcharset%3Dutf-8'%20http-equiv%3D'Content-Type'%3E%0A%20%20%20%20%3Cscript%20src%3D'https%3A%2F%2Fsverweij.github.io%2Fmscgen_js%2Fmscgen-inpage.js'%20defer%3E%0A%20%20%20%20%3C%2Fscript%3E%0A%20%20%3C%2Fhead%3E%0A%20%20%3Cbody%3E%0A%20%20%20%20%3Cpre%20class%3D'code%20mscgen%20mscgen_js'%3E%0Amsc%7Ba%5Blabel%3D%22%F0%9F%92%A9%22%5D%2Cb%5Blabel%3D%22%E5%BA%8F%22%5D%2Cc%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%3B%20a%20%3D%3E%20b%5Blabel%3D%22things%22%5D%2C%20c%20%3D%3E%20b%3B%7D%0A%20%20%20%20%3C%2Fpre%3E%0A%20%20%3C%2Fbody%3E%0A%3C%2Fhtml%3E");
         });
-    });
-    describe('#toHTMLSnippetURI with link to interpreter', function(){
-        it('should render an URI encoded html file with the passed chart embedded', function(){
-            assert.equal(xport.toHTMLSnippetURI(gMsc, 'mscgen', true),
-            "data:text/plain;charset=utf-8,%3C!DOCTYPE%20html%3E%0A%3Chtml%3E%0A%20%20%3Chead%3E%0A%20%20%20%20%3Cmeta%20content%3D'text%2Fhtml%3Bcharset%3Dutf-8'%20http-equiv%3D'Content-Type'%3E%0A%20%20%20%20%3Cscript%3E%0A%20%20%20%20%20%20var%20mscgen_js_config%20%3D%20%7B%0A%20%20%20%20%20%20%20%20clickable%3A%20true%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%3C%2Fscript%3E%0A%20%20%20%20%3Cscript%20src%3D'https%3A%2F%2Fsverweij.github.io%2Fmscgen_js%2Fmscgen-inpage.js'%20defer%3E%0A%20%20%20%20%3C%2Fscript%3E%0A%20%20%3C%2Fhead%3E%0A%20%20%3Cbody%3E%0A%20%20%20%20%3Cpre%20class%3D'code%20mscgen%20mscgen_js'%20data-language%3D'mscgen'%3E%0Amsc%7Ba%5Blabel%3D%22%F0%9F%92%A9%22%5D%2Cb%5Blabel%3D%22%E5%BA%8F%22%5D%2Cc%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%3B%20a%20%3D%3E%20b%5Blabel%3D%22things%22%5D%2C%20c%20%3D%3E%20b%3B%7D%0A%20%20%20%20%3C%2Fpre%3E%0A%20%20%3C%2Fbody%3E%0A%3C%2Fhtml%3E");
+        it('values that are defaults anyway do not end up in the generated HTML', function(){
+            assert.equal(
+                xport.toHTMLSnippetURI(
+                    gMsc,
+                    'mscgen',
+                    {
+                        withLinkToEditor: false,
+                        mirrorEntities: false,
+                        namedStyle: "none"
+                    }
+                ),
+                "data:text/plain;charset=utf-8,%3C!DOCTYPE%20html%3E%0A%3Chtml%3E%0A%20%20%3Chead%3E%0A%20%20%20%20%3Cmeta%20content%3D'text%2Fhtml%3Bcharset%3Dutf-8'%20http-equiv%3D'Content-Type'%3E%0A%20%20%20%20%3Cscript%20src%3D'https%3A%2F%2Fsverweij.github.io%2Fmscgen_js%2Fmscgen-inpage.js'%20defer%3E%0A%20%20%20%20%3C%2Fscript%3E%0A%20%20%3C%2Fhead%3E%0A%20%20%3Cbody%3E%0A%20%20%20%20%3Cpre%20class%3D'code%20mscgen%20mscgen_js'%3E%0Amsc%7Ba%5Blabel%3D%22%F0%9F%92%A9%22%5D%2Cb%5Blabel%3D%22%E5%BA%8F%22%5D%2Cc%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%3B%20a%20%3D%3E%20b%5Blabel%3D%22things%22%5D%2C%20c%20%3D%3E%20b%3B%7D%0A%20%20%20%20%3C%2Fpre%3E%0A%20%20%3C%2Fbody%3E%0A%3C%2Fhtml%3E");
         });
+        it('should render an URI encoded html file with a link to the interpreter', function(){
+            assert.equal(
+                xport.toHTMLSnippetURI(gMsGenny, 'msgenny', {"withLinkToEditor": true}),
+                "data:text/plain;charset=utf-8,%3C!DOCTYPE%20html%3E%0A%3Chtml%3E%0A%20%20%3Chead%3E%0A%20%20%20%20%3Cmeta%20content%3D'text%2Fhtml%3Bcharset%3Dutf-8'%20http-equiv%3D'Content-Type'%3E%0A%20%20%20%20%3Cscript%3E%0A%20%20%20%20%20%20var%20mscgen_js_config%20%3D%20%7B%0A%20%20%20%20%20%20%20%20clickable%3A%20true%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%3C%2Fscript%3E%0A%20%20%20%20%3Cscript%20src%3D'https%3A%2F%2Fsverweij.github.io%2Fmscgen_js%2Fmscgen-inpage.js'%20defer%3E%0A%20%20%20%20%3C%2Fscript%3E%0A%20%20%3C%2Fhead%3E%0A%20%20%3Cbody%3E%0A%20%20%20%20%3Cpre%20class%3D'code%20msgenny%20mscgen_js'%20data-language%3D'msgenny'%3E%0Aa%20%3A%20%F0%9F%92%A9%2C%20b%20%3A%20%E5%BA%8F%2C%20c%20%3A%20%F0%9F%92%A9%3B%20a%20%3D%3E%20b%20%3A%20things%2C%20c%20%3D%3E%20b%3B%0A%20%20%20%20%3C%2Fpre%3E%0A%20%20%3C%2Fbody%3E%0A%3C%2Fhtml%3E");
+        });
+        it('non-default values for mirrorEntities and namedStyle end up in the HTML', function(){
+            assert.equal(
+                xport.toHTMLSnippetURI(
+                    gMsGenny,
+                    'msgenny',
+                    {
+                        withLinkToEditor: false,
+                        mirrorEntities: true,
+                        namedStyle: "lazy"
+                    }
+                ),
+                "data:text/plain;charset=utf-8,%3C!DOCTYPE%20html%3E%0A%3Chtml%3E%0A%20%20%3Chead%3E%0A%20%20%20%20%3Cmeta%20content%3D'text%2Fhtml%3Bcharset%3Dutf-8'%20http-equiv%3D'Content-Type'%3E%0A%20%20%20%20%3Cscript%20src%3D'https%3A%2F%2Fsverweij.github.io%2Fmscgen_js%2Fmscgen-inpage.js'%20defer%3E%0A%20%20%20%20%3C%2Fscript%3E%0A%20%20%3C%2Fhead%3E%0A%20%20%3Cbody%3E%0A%20%20%20%20%3Cpre%20class%3D'code%20msgenny%20mscgen_js'%20data-language%3D'msgenny'%20data-named-style%3D'lazy'%20data-mirror-entities%3D'true'%3E%0Aa%20%3A%20%F0%9F%92%A9%2C%20b%20%3A%20%E5%BA%8F%2C%20c%20%3A%20%F0%9F%92%A9%3B%20a%20%3D%3E%20b%20%3A%20things%2C%20c%20%3D%3E%20b%3B%0A%20%20%20%20%3C%2Fpre%3E%0A%20%20%3C%2Fbody%3E%0A%3C%2Fhtml%3E");
+        });
+
     });
     describe('#todotURI', function(){
         it('should render an URI encoded string representing a graphviz dot program', function(){
@@ -85,10 +112,12 @@ describe('ui/utl/exporter', function(){
                 protocol: "http",
                 host: "localhost",
                 pathname: "mscgen_js/index.html",
-                search: '?debug=false&donottrack=true'
+                search: '?debug=false&donottrack=true&mirrorentities=on&style=none'
             };
-            assert.equal(xport.toLocationString(lLocation, gMsc, 'mscgen'),
-                        'mscgen_js/index.html?lang=mscgen&donottrack=true&debug=false&msc=msc%7Ba%5Blabel%3D%22%F0%9F%92%A9%22%5D%2Cb%5Blabel%3D%22%E5%BA%8F%22%5D%2Cc%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%3B%20a%20%3D%3E%20b%5Blabel%3D%22things%22%5D%2C%20c%20%3D%3E%20b%3B%7D');
+            assert.equal(
+                xport.toLocationString(lLocation, gMsc, 'mscgen'),
+                'mscgen_js/index.html?lang=mscgen&donottrack=true&debug=false&mirrorentities=on&style=none&msc=msc%7Ba%5Blabel%3D%22%F0%9F%92%A9%22%5D%2Cb%5Blabel%3D%22%E5%BA%8F%22%5D%2Cc%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%3B%20a%20%3D%3E%20b%5Blabel%3D%22things%22%5D%2C%20c%20%3D%3E%20b%3B%7D'
+            );
         });
         it('without extra parameters', function(){
             var lLocation = {
@@ -96,10 +125,10 @@ describe('ui/utl/exporter', function(){
                 host: "localhost",
                 pathname: "mscgen_js/index.html"
             };
-            assert.equal(xport.toLocationString(lLocation, gMsc, 'mscgen'),
-                        'mscgen_js/index.html?lang=mscgen&msc=msc%7Ba%5Blabel%3D%22%F0%9F%92%A9%22%5D%2Cb%5Blabel%3D%22%E5%BA%8F%22%5D%2Cc%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%3B%20a%20%3D%3E%20b%5Blabel%3D%22things%22%5D%2C%20c%20%3D%3E%20b%3B%7D');
-
-
+            assert.equal(
+                xport.toLocationString(lLocation, gMsc, 'mscgen'),
+                'mscgen_js/index.html?lang=mscgen&msc=msc%7Ba%5Blabel%3D%22%F0%9F%92%A9%22%5D%2Cb%5Blabel%3D%22%E5%BA%8F%22%5D%2Cc%20%5Blabel%3D%22%F0%9F%92%A9%22%5D%3B%20a%20%3D%3E%20b%5Blabel%3D%22things%22%5D%2C%20c%20%3D%3E%20b%3B%7D'
+            );
         });
         it('with a source that is too big (> 4k)', function(){
             var lLocation = {

--- a/src/script/test/utl/store.spec.js
+++ b/src/script/test/utl/store.spec.js
@@ -5,20 +5,26 @@ var store = require("../../utl/store");
 var assert = require("assert");
 
 describe('ui/utl/store', function() {
-    var lLanguage = "initial language";
-    var lSource = "initial source";
-    var lAutoRender = false;
-    var lDebug = false;
+    var lLanguage       = "initial language";
+    var lSource         = "initial source";
+    var lAutoRender     = false;
+    var lDebug          = false;
+    var lMirrorEntities = false;
+    var lNamedStyle     = null;
 
     var lState = {
-        getLanguage: function(){ return "other language"; },
-        setLanguage: function(pLanguage){ lLanguage = pLanguage; },
-        getSource: function(){ return "other source"; },
-        setSource: function(pSource){ lSource = pSource; },
-        getAutoRender: function(){ return true; },
-        setAutoRender: function(pAutoRender){ lAutoRender = pAutoRender; },
-        getDebug: function(){ return true; },
-        setDebug: function(pDebug){ lDebug = pDebug; }
+        getLanguage      : function() { return "other language"; },
+        setLanguage      : function(pLanguage){ lLanguage = pLanguage; },
+        getSource        : function() { return "other source"; },
+        setSource        : function(pSource){ lSource = pSource; },
+        getAutoRender    : function() { return true; },
+        setAutoRender    : function(pAutoRender){ lAutoRender = pAutoRender; },
+        getDebug         : function() { return true; },
+        setDebug         : function(pDebug){ lDebug = pDebug; },
+        getMirrorEntities: function() { return lMirrorEntities; },
+        setMirrorEntities: function(pMirrorEntities) { lMirrorEntities = pMirrorEntities; },
+        getStyle         : function() { return lNamedStyle; },
+        setStyle         : function(pNamedStyle) { lNamedStyle = pNamedStyle; }
     };
 
     describe('#load and save with no localStorage available', function() {

--- a/src/script/utl/exporter.js
+++ b/src/script/utl/exporter.js
@@ -39,6 +39,9 @@ function(ast2dot, ast2mscgen, ast2doxygen, par) {
         if (lParams.mirrorentities){
             lAdditionalParameters += '&mirrorentities=' + lParams.mirrorentities;
         }
+        if (lParams.style){
+            lAdditionalParameters += '&style=' + lParams.style;
+        }
         return lAdditionalParameters;
     }
 

--- a/src/script/utl/exporter.js
+++ b/src/script/utl/exporter.js
@@ -16,14 +16,60 @@ function(ast2dot, ast2mscgen, ast2doxygen, par) {
     /* max length of an URL on github (4122) - "https://sverweij.github.io/".length (27) - 1 */
     var MAX_LOCATION_LENGTH = 4094;
     var gTemplate =
-        "<!DOCTYPE html>\n<html>\n  <head>\n    <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>\n{{config}}    <script src='https://sverweij.github.io/mscgen_js/mscgen-inpage.js' defer>\n    </script>\n  </head>\n  <body>\n    <pre class='code {{language}} mscgen_js' data-language='{{language}}'>\n{{source}}\n    </pre>\n  </body>\n</html>";
+        "<!DOCTYPE html>\n" +
+        "<html>\n" +
+        "  <head>\n" +
+        "    <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>\n" +
+        "{{config}}" +
+        "    <script src='https://sverweij.github.io/mscgen_js/mscgen-inpage.js' defer>\n" +
+        "    </script>\n" +
+        "  </head>\n" +
+        "  <body>\n" +
+        "    <pre class='code {{language}} mscgen_js'{{data-language}}{{namedstyle}}{{mirrorentities}}>\n" +
+        "{{source}}\n" +
+        "    </pre>\n" +
+        "  </body>\n"  +
+        "</html>";
     var gLinkToEditorConfig =
-        "    <script>\n      var mscgen_js_config = {\n        clickable: true\n      }\n    </script>\n";
+        "    <script>\n" +
+        "      var mscgen_js_config = {\n" +
+        "        clickable: true\n" +
+        "      }\n" +
+        "    </script>\n";
 
-    function toHTMLSnippet (pSource, pLanguage, pWithLinkToEditor){
-        return gTemplate.replace(/{{config}}/g, pWithLinkToEditor ? gLinkToEditorConfig : "")
-                        .replace(/{{language}}/g, pLanguage)
-                        .replace(/{{source}}/g, pSource.replace(/</g, "&lt;"));
+
+    function extractNamedStyle(pNamedStyle) {
+        return pNamedStyle && pNamedStyle !== "none"
+            ? " data-named-style='" + pNamedStyle + "'"
+            : "";
+    }
+
+    function extractDataLanguage(pLanguage) {
+        return pLanguage && pLanguage !== "mscgen"
+            ? " data-language='" + pLanguage + "'"
+            : "";
+    }
+
+    function extractMirrorEntities(pMirrorEntities) {
+        return pMirrorEntities ? " data-mirror-entities='true'" : "";
+    }
+
+    function extractLinkToEditor(pWithLinkToEditor) {
+        return pWithLinkToEditor ? gLinkToEditorConfig : "";
+    }
+
+    function extractSource(pSource) {
+        return pSource.replace(/</g, "&lt;");
+    }
+
+    function toHTMLSnippet (pSource, pLanguage, pOptions){
+        return gTemplate
+            .replace(/{{config}}/g, extractLinkToEditor(pOptions.withLinkToEditor))
+            .replace(/{{language}}/g, pLanguage)
+            .replace(/{{data-language}}/g, extractDataLanguage(pLanguage))
+            .replace(/{{mirrorentities}}/g, extractMirrorEntities(pOptions.mirrorEntities))
+            .replace(/{{namedstyle}}/g, extractNamedStyle(pOptions.namedStyle))
+            .replace(/{{source}}/g, extractSource(pSource));
     }
 
     function getAdditionalParameters(pLocation){
@@ -62,9 +108,9 @@ function(ast2dot, ast2mscgen, ast2doxygen, par) {
             encodeURIComponent(pSVGSource);
         },
         toHTMLSnippet: toHTMLSnippet,
-        toHTMLSnippetURI: function(pSource, pLanguage, pWithLinkToEditor){
+        toHTMLSnippetURI: function(pSource, pLanguage, pOptions){
             return 'data:text/plain;charset=utf-8,' +
-                    encodeURIComponent(toHTMLSnippet(pSource, pLanguage, pWithLinkToEditor));
+                    encodeURIComponent(toHTMLSnippet(pSource, pLanguage, pOptions));
         },
         todotURI: function(pAST){
             return 'data:text/plain;charset=utf-8,' +

--- a/src/script/utl/store.js
+++ b/src/script/utl/store.js
@@ -29,10 +29,12 @@ define([], function() {
             localStorage.setItem(
                 STORAGE_KEY,
                 JSON.stringify({
-                    language: pState.getLanguage(),
-                    source: pState.getSource(),
-                    autorender: pState.getAutoRender(),
-                    debug: pState.getDebug()
+                    language       : pState.getLanguage(),
+                    source         : pState.getSource(),
+                    autorender     : pState.getAutoRender(),
+                    debug          : !pState.getDebug(),
+                    mirrorEntities : pState.getMirrorEntities(),
+                    namedStyle     : pState.getStyle()
                 })
             );
         }
@@ -41,10 +43,12 @@ define([], function() {
     function load(pState){
         var lState = getState();
         if (lState){
-            pState.setLanguage(lState.language);
-            pState.setSource(lState.source);
             pState.setAutoRender(lState.autorender);
             pState.setDebug(lState.debug);
+            pState.setMirrorEntities(lState.mirrorEntities);
+            pState.setStyle(lState.namedStyle);
+            pState.setLanguage(lState.language);
+            pState.setSource(lState.source);
         }
     }
 

--- a/src/script/utl/store.js
+++ b/src/script/utl/store.js
@@ -32,7 +32,7 @@ define([], function() {
                     language       : pState.getLanguage(),
                     source         : pState.getSource(),
                     autorender     : pState.getAutoRender(),
-                    debug          : !pState.getDebug(),
+                    debug          : pState.getDebug(),
                     mirrorEntities : pState.getMirrorEntities(),
                     namedStyle     : pState.getStyle()
                 })

--- a/src/tutorial.html
+++ b/src/tutorial.html
@@ -254,7 +254,7 @@ ga ('send', 'pageview');
 </article>
 <article itemscope itemtype="http://schema.org/Article" id="msc-cheat-sheet">
     <h1 itemprop="name">Msc Cheat sheet</h1>
-    <pre class="mscgen_js hideonmobile" data-language="msgenny"># MsGenny: a cheat sheet
+    <pre class="mscgen_js hideonmobile" data-named-style="lazy" data-language="msgenny"># MsGenny: a cheat sheet
 hscale=0.9;
 
 a -> b   : a -> b  (signal),
@@ -291,8 +291,7 @@ c abox c : c abox c\n(state/ condition);
 |||      : ||| (empty row);
 ...      : ... (omitted row);
  ---      : --- (comment);</pre>
-<pre class="mscgen_js showonmobile" data-language="msgenny">a, b;
-
+<pre class="mscgen_js showonmobile" data-named-style="lazy" data-language="msgenny">
 a -> b   : a -> b  (signal);
 a => b   : a => b  (method);
 b >> a   : b >> a  (return value);
@@ -383,7 +382,7 @@ b => c  : Breaking text in two<mark>\n</mark>also works for arcs;
 b => c  : Breaking text in two\nalso works for arcs;</pre>
 <p class="info">Everything in boxes wraps automatically. Regular arcs also do that when
 the <a href="#wordwraparcs"><code>wordwraparcs</code></a> option is on. We're thinking
-of having this as the default somewhere in the future, but haven't yet because of 
+of having this as the default somewhere in the future, but haven't yet because of
 backwards compatibility.
 </p>
 


### PR DESCRIPTION
This PR/ branch has two goals
- To explore if _automatically_ saving to local storage e.g. directly after rendering is _usable_
- In order to fully experiment with that, all three options for remembering things need to include the new features that influence how the chart gets rendered (mirror entities and named styles)

(These are the three options for remembering things:
- GET parameters
- local storage
- embedding the chart in html)