### PR TITLE
bugfix(exporter): add a doctype + entity declaration to the svg export

### DIFF
--- a/src/script/interpreter/raster-exporter.js
+++ b/src/script/interpreter/raster-exporter.js
@@ -29,11 +29,13 @@ module.exports = {
 
     lImg.src = 'data:image/svg+xml;charset=utf-8,' +
                     encodeURIComponent(
-                      geckoRelativeSizeWorkaround(
-                        svgutensils.webkitNamespaceBugWorkaround(
-                          pSVGParent.innerHTML
-                        ),
-                        pSVGParent.firstElementChild.viewBox
+                      '<!DOCTYPE svg [<!ENTITY nbsp "&#160;">]>'.concat(
+                        geckoRelativeSizeWorkaround(
+                          svgutensils.webkitNamespaceBugWorkaround(
+                            pSVGParent.innerHTML
+                          ),
+                          pSVGParent.firstElementChild.viewBox
+                        )
                       )
                     )
     lImg.addEventListener('load', function (pEvent) {

--- a/src/script/test/utl/exporter.spec.js
+++ b/src/script/test/utl/exporter.spec.js
@@ -46,7 +46,7 @@ describe('ui/utl/exporter', function () {
   describe('#toVectorURI', function () {
     it('Should render an URI encoded svg', function () {
       assert.strictEqual(xport.toVectorURI(gSVG),
-        'data:image/svg+xml;charset=utf-8,%3Csvg%3Ejust%20a%20dummy%20thing%3C%2Fsvg%3E')
+        'data:image/svg+xml;charset=utf-8,%3C!DOCTYPE%20svg%20%5B%3C!ENTITY%20nbsp%20%22%26%23160%3B%22%3E%5D%3E%3Csvg%3Ejust%20a%20dummy%20thing%3C%2Fsvg%3E')
     })
   })
   describe('#toHTMLSnippetURI', function () {

--- a/src/script/utl/exporter.js
+++ b/src/script/utl/exporter.js
@@ -102,7 +102,7 @@ function sourceIsURLable (pLocation, pSource, pLanguage, pMirrorEntities, pNamed
 module.exports = {
   toVectorURI: function (pSVGSource) {
     return 'data:image/svg+xml;charset=utf-8,' +
-        encodeURIComponent(pSVGSource)
+        encodeURIComponent('<!DOCTYPE svg [<!ENTITY nbsp "&#160;">]>'.concat(pSVGSource))
   },
   toHTMLSnippet: toHTMLSnippet,
   toHTMLSnippetURI: function (pSource, pLanguage, pOptions) {


### PR DESCRIPTION
... so the &nbsp; some browsers lately insert for non-breaking spaces are defined

## Description, Motivation and Context
Fixes #257 (also for the raster graphics, because the root cause was the same)

## How Has This Been Tested?
- [x] non-regression unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] The code I add will be subject to [GPL-3.0](../wikum/licenses/license.mscgen_js.md), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.